### PR TITLE
UXWS-1034 Update LibWizard header with a11y and privacy links

### DIFF
--- a/libwizard/custom-head.html
+++ b/libwizard/custom-head.html
@@ -8,65 +8,6 @@
 <!--meta tag to scale mobile device display-->
 <meta name="viewport" content="width=device-width, maximum-scale=1">
 
-<script type="text/javascript">
-jQuery(document).ready(function($) {
-  jQuery("img[alt='null'], img[alt='Null'], img[alt='NULL']").attr("alt", "");
-  var libchat_efc75c55947db323d4faab725b79307f = { iid:59, key:'fb10446730e271c', width:'240' };
-
-  $('header .menu--toggle').click(function(){
-    $('#nav-main').toggleClass('active');
-    $('.wrap-page').toggleClass('mobile-nav-active');
-  });
-
-  $( '.link-primary' ).bind( "mouseenter", function() { 
-    $( '.link-primary' ).removeClass( 'open' );
-    $(this).find( '.menu-control' ).attr( 'aria-expanded', 'true' );
-    $(this).closest( '.link-primary' ).addClass( 'open' );
-  });
-  $( '.link-primary' ).bind( "mouseleave", function() { 
-    $(this).find( '.menu-control' ).attr( 'aria-expanded', 'false' );
-    $( '.link-primary' ).removeClass( 'open' );
-  });
-
-  // make esc close all menus
-  $( '#nav-main' ).on( 'keydown' , function(e) {
-    if (e.keyCode == 27) {
-      hideMenu(e);
-    }
-  });
-
-  function hideMenu() {
-    $( '.link-primary' ).removeClass( 'open' );
-    $( '.menu-control' ).attr('aria-expanded', 'false');
-    $( '.links-sub' ).attr( 'aria-hidden', 'true' );
-  }
-
-  // thanks to http://heydonworks.com/practical_aria_examples/
-  $('.main-nav-header').each(function() {
-
-    var $this = $(this);
-
-    // create unique id for a11y relationship
-    var id = 'collapsible-' + $( '#nav-main h2' ).index(this);
-
-    // identify panel and make it focusable
-    var panel = $(this).next( '.links-sub' ).attr( 'aria-hidden', 'true' ).attr( 'id', id);
-
-    // Add default aria states to button
-    $this.children( '.menu-control' ).attr( 'aria-expanded', 'false' ).attr( 'aria-controls', id);
-    var button = $this.children( '.menu-control' );
-
-    // Toggle the state properties
-    button.on( 'click', function() {
-      $(this).closest( '.link-primary' ).toggleClass( 'open' );
-      var state = $(this).attr( 'aria-expanded' ) === 'false' ? true : false;
-      $(this).attr( 'aria-expanded', state );
-      panel.attr( 'aria-hidden', !state );
-    });
-  });
-});
-</script>
-
 <style type="text/css">
 /* Basic layout rules */
 * {
@@ -143,20 +84,13 @@ h3 {
   max-height: 100%;
 }
 
-@media only screen and (min-width:569px) {
-  .header-main {
-    width: 100%
-  }
-}
-
-@media only screen and (min-width:569px) {
-  .header-main {
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
-    padding: 0 1em
-  }
+.header-main {
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0 1em
+  width: 100%;
 }
 
 .header-main>[class*=link] {
@@ -174,11 +108,13 @@ h3 {
   }
 }
 
-.header-main .logo-mit-lib {
+.header-main .logo-mit-lib,
+.headder-main .link-logo-mit {
   fill: #fff
 }
 
-.header-main .logo-mit-lib svg {
+.header-main .logo-mit-lib svg,
+.header-main .link-logo-mit svg {
   max-height: 44px;
   max-height: 1.75rem;
   height: auto; 
@@ -194,95 +130,41 @@ h3 {
   }
 }
 
-.header-main .link-account {
-  margin-right: 1em;
-  margin-left: 2em
+.header-main .link-logo-mit {
+  max-width: 59px;
+  max-width: 59px;
+  max-width: 3.6875rem;
 }
 
 .header-main .link-logo-mit {
-  display: none;
-  max-width: 59px;
-  max-width: 59px;
-  max-width: 3.6875rem
-}
-
-@media only screen and (min-width:569px) {
-  .header-main .link-logo-mit {
-    -webkit-align-self: flex-end;
-    -ms-flex-item-align: end;
-    align-self: flex-end;
-    display: block;
-    -webkit-box-ordinal-group: 5;
-    -webkit-order: 4;
-    -ms-flex-order: 4;
-    order: 4;
-    margin-bottom: 8px;
-    margin-bottom: .5rem
-  }
-}
-
-.header-main .link-site-search {
-  margin-left: auto
-}
-
-.header-main .link-account,
-.header-main .link-site-search {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  line-height: 1;
-  padding-bottom: 8px;
-  padding-bottom: .5rem
-}
-
-.header-main .link-account svg,
-.header-main .link-site-search svg {
-  fill: #fff;
-  margin: 0 auto;
-  padding-bottom: .25em;
-  width: 2em
-}
-
-@media only screen and (min-width:569px) {
-  .header-main .link-account,
-  .header-main .link-site-search {
-    display: none
-  }
+  -webkit-box-ordinal-group: 5;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+  margin-bottom: 8px;
+  margin-bottom: .5rem
 }
 
 .header-main .logo-mit {
-  display: none;
-  margin-left: .5em
+  height: auto;
+  max-height: 45px;
+  max-height: 2.8125rem;
+  fill: #b9b7b6
 }
-
-@media only screen and (min-width:569px) {
-  .header-main .logo-mit {
-    display: block;
-    height: auto;
-    max-height: 45px;
-    max-height: 2.8125rem;
-    fill: #b9b7b6
-  }
-  .header-main .logo-mit .color {
-    fill: #fff
-  }
+.header-main .logo-mit .color {
+  fill: #fff
 }
 
 .header-main .name-site {
   font-size: 14.4px;
   font-size: .9rem;
   line-height: 1;
-  margin-top: -1.25em;
-  margin-left: -.25em;
+  margin-top: 1.25em;
+  margin-left: .25em;
   -webkit-box-ordinal-group: 3;
   -webkit-order: 2;
   -ms-flex-order: 2;
@@ -360,7 +242,7 @@ h3 {
 }
 
 @media only screen and (max-width:320px) {
-  .no-flexbox.flexboxlegacy .header-main .menu--toggle svg {
+  .no-flexbox.flexboxlegacy .header-main svg {
     height: 100%;
     padding: 1em;
     width: auto
@@ -394,29 +276,11 @@ h3 {
   display: none
 }
 
-.nav-main {
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-transform: translateY(-1000%);
-  -ms-transform: translateY(-1000%);
-  transform: translateY(-1000%);
-  z-index: 7000;
-  margin: 0;
-  padding: 0;
-  width: 0;
-  height: 0;
-  overflow: hidden
-}
-
 .nav-main.active {
   font-size: 16px;
   font-size: 1rem;
   padding: 0 8px 8px;
   padding: 0 .5rem .5rem;
-  background: #fff;
-  -webkit-box-shadow: 0 3px 3px #ccc;
-  box-shadow: 0 3px 3px #ccc;
   height: auto;
   -webkit-box-flex: 0;
   -webkit-flex: none;
@@ -434,11 +298,6 @@ h3 {
   width: 100%
 }
 
-.nav-main.active a:focus,
-.nav-main.active a:hover {
-  color: #fff
-}
-
 @media only screen and (max-width:1023px) {
   .nav-main {
     font-size: .9em
@@ -451,136 +310,44 @@ h3 {
   }
 }
 
-@media only screen and (min-width:569px) {
-  .nav-main {
-    -webkit-box-align: stretch;
-    -webkit-align-items: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-    height: auto;
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    -webkit-box-ordinal-group: 4;
-    -webkit-order: 3;
-    -ms-flex-order: 3;
-    order: 3;
-    overflow: visible;
-    width: auto;
-    -webkit-transform: translateY(0%);
-    -ms-transform: translateY(0%);
-    transform: translateY(0%)
-  }
-}
-
-.nav-main .chat,
-.nav-main .small {
-  display: none
-}
-
-@media only screen and (min-width:569px) {
-  .nav-main .small {
-    display: block;
-    font-size: .5em
-  }
-  .nav-main .small a {
-    padding-bottom: 8px;
-    padding-bottom: .5rem;
-    -webkit-box-align: center;
-    -webkit-align-items: center;
-    -ms-flex-align: center;
-    align-items: center;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    text-transform: uppercase
-  }
-  .nav-main .small svg {
-    display: block;
-    fill: #fff;
-    margin-bottom: 1em
-  }
-}
-
-@media only screen and (max-width:1023px) {
-  .nav-main .small {
-    font-size: 1em
-  }
-  .nav-main .small a {
-    text-transform: none
-  }
-  .nav-main .small svg {
-    display: none
-  }
-}
-
-@media only screen and (min-width:569px) {
-  .nav-main .chat {
-    display: block
-  }
-  .nav-main .chat .links-sub {
-    min-width: 150px;
-    min-width: 9.375rem;
-    background: #f3f3f3;
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-    width: auto
-  }
-  .nav-main .chat .links-sub a:focus,
-  .nav-main .chat .links-sub a:hover {
-    background: 0 0
-  }
-  .nav-main .chat .more {
-    font-size: 12px;
-    font-size: .75rem;
-    display: block;
-    text-align: center;
-    text-transform: none;
-    width: 100%
-  }
-  .nav-main .chat .wrap-button-chat {
-    min-height: 46px;
-    min-height: 2.875rem;
-    padding: 16px 8px 0;
-    padding: 1rem .5rem 0;
-    min-width: 100%
-  }
-  .nav-main .chat .wrap-button-chat #libchat_btn_widget {
-    border: 1px solid #666
-  }
+.nav-main {
+  -webkit-box-align: stretch;
+  -webkit-align-items: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  height: auto;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-ordinal-group: 4;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+  overflow: visible;
+  width: auto;
+  -webkit-transform: translateY(0%);
+  -ms-transform: translateY(0%);
+  transform: translateY(0%);
 }
 
 .nav-main .nav-main-list {
-  display: block
-}
-
-@media only screen and (min-width:569px) {
-  .nav-main .nav-main-list {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-align: stretch;
-    -webkit-align-items: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch
-  }
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: flex-end;
+  -webkit-align-items: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  margin-left: 1rem;
+  margin-right: 1rem;
 }
 
 .nav-main .link-primary {
   position: relative;
   -webkit-transition: background-color .3s;
   transition: background-color .3s;
-  width: 100%
-}
-
-@media only screen and (min-width:569px) {
-  .nav-main .link-primary {
-    width: auto
-  }
+  width: auto;
 }
 
 .nav-main .main-nav-header {
@@ -588,26 +355,19 @@ h3 {
   font-size: 100%
 }
 
-.nav-main .main-nav-link {
+.nav-main .main-nav-link,
+.nav-main .main-nav-divider {
+  border-bottom: none;
+  color: #fff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 100%;
+  text-decoration: none;
   padding: 8px;
   padding: .5rem;
-  display: block;
-  position: relative; 
-  text-decoration: none;
-}
-
-@media only screen and (min-width:569px) {
-  .nav-main .main-nav-link {
-    border-bottom: none;
-    color: #fff;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    height: 100%;
-    text-decoration: none;
-    padding-top: 2em
-  }
+  padding-top: 2em
 }
 
 .nav-main .main-nav-link.active {
@@ -637,88 +397,10 @@ h3 {
   background: #fff
 }
 
-.nav-main .links-sub {
-  display: none;
-  left: 0;
-  max-height: 0;
-  opacity: 0;
-  overflow: hidden;
-  position: absolute;
-  top: 100%;
-  -webkit-transition: max-height .3s, margin .3s, opacity .3s, overflow .3s, padding-top .3s, padding-bottom .3s;
-  transition: max-height .3s, margin .3s, opacity .3s, overflow .3s, padding-top .3s, padding-bottom .3s;
-  width: 31.75em
-}
-
-.nav-main .links-sub.push {
-  left: auto;
-  right: 0
-}
-
 @media only screen and (min-width:569px) {
   .nav-main .link-primary.open .main-nav-link {
     background: #C702C7
   }
-}
-
-.nav-main .link-primary.open .links-sub {
-  display: none
-}
-
-@media only screen and (min-width:569px) {
-  .nav-main .link-primary.open .links-sub {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border: 1px solid #000;
-    border-top: 0;
-    max-height: 1000px;
-    opacity: 1;
-    overflow: visible
-  }
-}
-
-.nav-main .links-sub a {
-  color: #000;
-  display: block;
-  font-weight: 600;
-  padding: .5em
-}
-
-.nav-main .links-sub a:focus,
-.nav-main .links-sub a:hover {
-  background: #C702C7;
-  color: #fff;
-  tect-decoration: none;
-}
-
-.nav-main .links-sub [class*=col-] {
-  width: 50%
-}
-
-.nav-main .links-sub .about {
-  display: block;
-  font-size: .6875em;
-  font-weight: 400
-}
-
-.nav-main .links-sub .bottom {
-  border-top: 1px solid #000
-}
-
-.nav-main .links-sub .bottom.extra span:first-of-type:after,
-.nav-main .links-sub .bottom:not(.extra):after {
-  content: url(/wp-content/themes/libraries/images/arrow-right-sfw.svg);
-  display: inline-block;
-  margin-left: .25em
-}
-
-.nav-main .bottom:not(.extra) span:not(:first-of-type):before {
-  color: #000;
-  content: '|';
-  display: inline-block;
-  margin-right: 4px
 }
 
 .nav-main .heading-col {
@@ -755,39 +437,6 @@ h3 {
   width: 600px
 }
 
-
-
-.mobile-display {
-  display: none
-}
-
-.menu--toggle {
-  min-width: 51px;
-  min-width: 3.1875rem;
-  font-size: 16px;
-  font-size: 1rem;
-  background: #111;
-  cursor: pointer;
-  fill: #ebf5ff;
-  -webkit-box-ordinal-group: 2;
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-  width: 14.375%;
-  z-index: 7000
-}
-
-@media only screen and (min-width:569px) {
-  .menu--toggle {
-    display: none
-  }
-}
-
-.menu--toggle svg {
-  display: block;
-  margin: 1em auto
-}
-
 .no-flexbox .link-primary.chat:focus .links-sub,
 .no-flexbox .link-primary.chat:hover .links-sub {
   display: block
@@ -803,411 +452,7 @@ h3 {
   display: none
 }
 
-/* 2. Footer */
-.footer-main {
-  background: #000 url('https://libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 0 65%;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  clear: both;
-  width: 100%
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main {
-    padding: 2em 1.375em
-  }
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main {
-    width: 100%
-  }
-}
-
-.footer-main a {
-  color: #fff
-}
-
-.footer-main .identity {
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 2em 0 0
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .identity {
-    -webkit-box-align: end;
-    -webkit-align-items: flex-end;
-    -ms-flex-align: end;
-    align-items: flex-end;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
-    width: 100%
-  }
-}
-
-.footer-main .links-all {
-  display: none
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-all {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    width: 100%
-  }
-}
-
-.footer-main .links-all h4 {
-  font-size: 1.125em;
-  font-weight: 400;
-  padding-bottom: 1em
-}
-
-.footer-main .links-all .flex-item {
-  margin-right: 1.75em
-}
-
-.footer-main .links-all .link-sub {
-  display: block;
-  font-size: .75em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-all .link-sub {
-    font-size: .75em;
-    font-weight: 300
-  }
-  .footer-main .links-all .link-sub:not(:last-of-type) {
-    padding-bottom: 1em
-  }
-}
-
-.footer-main .links-primary {
-  border-top: 1px solid #808285;
-  border-bottom: 1px solid #808285;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  font-size: .8125em;
-  margin-top: 2em;
-  padding: 2rem 1.375rem;
-  width: 100%
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-primary {
-    border-top: none;
-    border-bottom: none;
-    font-size: .875em;
-    margin-top: -22.4px;
-    margin-top: -1.4rem;
-    margin-left: 184px;
-    margin-left: 11.5rem;
-    padding: 0;
-    z-index: 3000
-  }
-}
-
-@media only screen and (max-width:1023px) {
-  .footer-main .links-primary {
-    margin-top: 24px;
-    margin-top: 1.5rem;
-    margin-left: 0;
-    margin-left: 0
-  }
-}
-
-.footer-main .links-primary span {
-  display: block;
-  width: 50%
-}
-
-.footer-main .links-primary span:not(:last-of-type) {
-  margin-bottom: 1.5em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-primary span {
-    font-weight: 300;
-    padding-left: 1em;
-    width: auto
-  }
-  .footer-main .links-primary span:not(:last-of-type):after {
-    color: #dedede;
-    content: '|';
-    display: inline-block;
-    margin-left: 1em
-  }
-}
-
-@media only screen and (max-width:1023px) {
-  .footer-main .links-primary span:first-of-type {
-    padding-left: 0
-  }
-}
-
-.footer-main .logo-mit-lib {
-  display: block;
-  fill: #fff;
-  padding-left: 1.375em;
-  width: 10.3125em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .logo-mit-lib {
-    padding-left: 0;
-    max-width: 9.5em;
-    width: 9.5em
-  }
-}
-
-.footer-main .logo-mit-lib svg {
-  max-height: 4em;
-  max-width: 9.5em
-}
-
-.footer-main .text-find-us {
-  color: #fff;
-  display: none;
-  font-size: .625em;
-  font-weight: 700;
-  text-transform: uppercase;
-  min-width: 7em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .text-find-us {
-    display: block
-  }
-}
-
-.footer-main .social {
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding-left: 1.375em;
-  width: auto
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social {
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    margin-bottom: -.8em;
-    z-index: 4000
-  }
-}
-
-.footer-main .social a {
-  width: 33%
-}
-
-.footer-main .social a:hover {
-  text-decoration: none
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social a {
-    width: 20%
-  }
-  .footer-main .social a:not(:last-of-type) {
-    margin-right: .5em
-  }
-}
-
-.footer-main .social [class*=icon-social] {
-  background: #fff;
-  -webkit-border-radius: 50%;
-  border-radius: 50%;
-  height: 1.5em;
-  padding: .2em;
-  width: 1.5em
-}
-
-.footer-main .social [class*=icon-social] path {
-  fill: #000
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social [class*=icon-social] {
-    height: 2em;
-    padding: .2em;
-    width: 2em
-  }
-}
-
-.footer-info-institute {
-  -webkit-box-align: baseline;
-  -webkit-align-items: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-  background: #333;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 1.5em 1em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row
-  }
-}
-
-.footer-info-institute .about-mit {
-  font-size: .625em;
-  margin-bottom: 2em
-}
-
-.footer-info-institute .about-mit span {
-  color: #eee;
-  text-transform: uppercase
-}
-
-.footer-info-institute .about-mit span:first-of-type {
-  font-weight: 700
-}
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute .about-mit span {
-    color: #ededed
-  }
-  .footer-info-institute .about-mit span:not(:last-of-type):after {
-    content: '|';
-    font-weight: 400
-  }
-}
-
-.footer-info-institute .license {
-  color: #ededed;
-  font-size: .6875em;
-  width: 100%
-}
-
-.footer-info-institute .license a {
-  color: #ededed
-}
-
-.footer-info-institute .link-mit-home {
-  display: block
-}
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute .link-mit-home {
-    margin: 0 1em 1.5em 0
-  }
-}
-
-.footer-info-institute .logo-mit {
-  fill: #bbb9b8;
-  width: 3.375em
-}
-
-.footer-info-institute .logo-mit .color {
-  fill: #ededed
-}
-
-.no-flexbox .footer-info-institute {
-  display: block
-}
-
-.no-flexbox .footer-info-institute:after {
-  clear: both;
-  content: '';
-  display: table
-}
-
-.no-flexbox .footer-info-institute>a,
-.no-flexbox .footer-info-institute>div {
-  float: left
-}
-
-.no-flexbox .footer-info-institute .about-mit {
-  padding-top: 4em
-}
-
-.no-flexbox .footer-info-institute .link-mit-home {
-  padding-top: 1.5em
-}
-
-.no-flexbox .footer-main.flex-container {
-  display: block;
-  float: left
-}
-
-.no-flexbox .footer-main:after {
-  clear: both;
-  content: '';
-  display: table
-}
-
-.no-flexbox .footer-main .identity {
-  position: relative;
-  width: 100%
-}
-
-.no-flexbox .footer-main .identity .logo-mit-lib {
-  display: block;
-  float: left
-}
-
-.no-flexbox .footer-main .identity .social {
-  bottom: 0;
-  display: block;
-  right: 22px;
-  position: absolute
-}
-
-.no-flexbox .footer-main .links-primary {
-  display: block;
-  margin-top: 0;
-  margin-left: 0;
-  left: 202px;
-  position: absolute;
-  top: 79px;
-  width: 100%
-}
-
-.no-flexbox .footer-main .links-primary span {
-  display: block;
-  float: left;
-  position: relative
-}
-
-.no-flexbox.flexboxlegacy .footer-main {
-  overflow-x: hidden
-}
-
-.lte-ie9.no-flexbox .footer-main .identity {
-  width: 100%
-}
-
-/* 3. no-flexbox fallbacks */
+/* 2. no-flexbox fallbacks */
 .no-flexbox.no-flexboxlegacy .flex-clear {
   clear: both
 }
@@ -1243,7 +488,7 @@ h3 {
   float: left
 }
 
-/* 4. hiding and showing elements based on mobile classes */
+/* 3. hiding and showing elements based on mobile classes */
 .hidden-mobile {
   display: none;
 }
@@ -1467,7 +712,7 @@ height:auto;
 #logo {
   margin-bottom: 2%;
   background-color: #000 !important;
-  padding: 0;
+  padding: 0 1rem;
 }
 
 #logo .header-main {

--- a/libwizard/custom-header.html
+++ b/libwizard/custom-header.html
@@ -4,191 +4,20 @@
       <span class="sr">MIT Libraries</span>
     </a><!-- End MIT Libraries Logo -->
   </h1><!-- End div.name-site -->
-  <div class="menu--toggle"><!-- Mobile Hamburger icon -->
-    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="18.909px" height="13.091px" viewBox="2.182 6.545 18.909 13.091" enable-background="new 2.182 6.545 18.909 13.091" xml:space="preserve"><path d="M2.909,6.545h17.454c0.197,0,0.367,0.072,0.512,0.216c0.145,0.144,0.216,0.314,0.216,0.511s-0.071,0.367-0.216,0.511
-    c-0.145,0.144-0.314,0.216-0.512,0.216H2.909c-0.197,0-0.367-0.072-0.511-0.216C2.254,7.639,2.182,7.469,2.182,7.272
-    s0.072-0.367,0.216-0.511C2.542,6.617,2.712,6.545,2.909,6.545z M20.363,13.818H2.909c-0.197,0-0.367-0.072-0.511-0.216
-    s-0.216-0.314-0.216-0.511c0-0.196,0.072-0.367,0.216-0.511s0.314-0.216,0.511-0.216h17.454c0.197,0,0.367,0.072,0.512,0.216
-    s0.216,0.314,0.216,0.511c0,0.197-0.071,0.367-0.216,0.511S20.561,13.818,20.363,13.818z M20.363,19.636H2.909
-    c-0.197,0-0.367-0.071-0.511-0.216s-0.216-0.314-0.216-0.511s0.072-0.367,0.216-0.511c0.144-0.145,0.314-0.217,0.511-0.217h17.454
-    c0.197,0,0.367,0.072,0.512,0.217c0.145,0.144,0.216,0.314,0.216,0.511s-0.071,0.366-0.216,0.511S20.561,19.636,20.363,19.636z"/>
-    </svg>
-  </div><!-- end hamburger icon -->
-  <nav id="nav-main" class="nav-main" aria-label="Primary">
-  <ul class="nav-main-list flex-container">
-    <li class="link-primary flex-end">
-      <h2 class="main-nav-header">
-        <a id="main-nav-searchmenu-title" href="https://libraries.mit.edu/search" class="no-underline search-link main-nav-link">Search</a>
-        <button class="menu-control sr">Search menu</button>
-      </h2>
-      <div aria-labelledby="main-nav-searchmenu-title" id="main-nav-searchmenu" class="links-sub flex-container group">
-        <div class="col-1 flex-item">
-          <h3 class="heading-col">Start here</h3>
-          <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
-            <li><a href="https://libraries.mit.edu/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Classic catalog search</span></a></li>
-            <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton-reserves">Course reserves</a></li>
-            <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
-          </ul>
-        </div>
-        <div class="col-2 flex-item">
-          <h3 class="heading-col">Also try</h3>
-          <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
-            <li><a href="https://libraries.mit.edu/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
-            <li><a href="https://libraries.mit.edu/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
-            <li><a href="https://libraries.mit.edu/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/site-search">Site search</a></li>
-          </ul>
-        </div>
-      </div><!-- end div.links-sub -->
-    </li><!-- end div.links-primary -->
-    <li class="link-primary flex-end">
-      <h2 class="main-nav-header">
-        <a id="main-nav-hoursmenu-title" href="https://libraries.mit.edu/hours" class="no-underline main-nav-link">Hours &amp; locations</a>
-        <button class="menu-control sr">Hours &amp; locations menu</button>
-      </h2>
-      <div aria-labelledby="main-nav-hoursmenu-title" id="main-nav-hoursmenu" class="links-sub flex-container group">
-        <div class="col-1 flex-item">
-          <h3 class="heading-col">Locations</h3>
-          <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/barker">Barker Library</a></li>
-            <li><a href="https://libraries.mit.edu/dewey">Dewey Library</a></li>
-            <li><a href="https://libraries.mit.edu/hayden">Hayden Library</a></li>
-            <li><a href="https://libraries.mit.edu/rotch">Rotch Library</a></li>
-            <li><a href="https://libraries.mit.edu/distinctive-collections">Distinctive Collections</a></li>
-            <li><a href="https://libraries.mit.edu/music">Lewis Music Library</a></li>
-            <li><a href="https://libraries.mit.edu/lsa">Library Storage Annex</a></li>
-            <li><a href="https://libraries.mit.edu/hours" class="bottom">All hours &amp; locations</a></li>
-          </ul>
-        </div>
-        <div class="col-2 flex-item">
-          <h3 class="heading-col">Using the Libraries</h3>
-          <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/locations">Map of locations</a></li>
-            <li><a href="https://libraries.mit.edu/study">Study spaces</a></li>
-            <li><a href="https://libraries.mit.edu/disabilities">Persons with disabilities</a></li>
-            <li><a href="https://libraries.mit.edu/copying">Scan, copy, print</a></li>
-            <li><a href="https://libraries.mit.edu/exhibits">Exhibits &amp; galleries</a></li>
-            <li><a href="https://libraries.mit.edu/visitors">Non-MIT visitors</a></li>
-            <li><a href="https://libraries.mit.edu/use-policies">Library use policy</a></li>
-          </ul>
-        </div>
-      </div><!-- end div.links-sub -->
-    </li><!-- end div.links-primary -->
-    <li class="link-primary flex-end">
-      <h2 class="main-nav-header">
-        <a id="main-nav-borrowmenu-title" href="https://libraries.mit.edu/borrow" class="no-underline main-nav-link">Borrow &amp; request</a>
-        <button class="menu-control sr">Borrow &amp; request menu</button>
-      </h2>
-      <div aria-labelledby="main-nav-borrowmenu-title" id="main-nav-borrowmenu" class="links-sub flex-container group">
-        <div class="col-1 flex-item">
-          <h3 class="heading-col">Renew, request, suggest</h3>
-          <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/barton-account">Your Account <span class="about">Renew MIT items</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
-            <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
-            <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
-            <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
-            <li><a href="https://libraries.mit.edu/borrow" class="bottom">More options &amp; help</a></li>
-          </ul>
-        </div>
-        <div class="col-2 flex-item">
-          <h3 class="heading-col">More information</h3>
-          <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
-            <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>
-          </ul>
-        </div>
-      </div>
-    </li>
-    <li class="link-primary flex-end">
-      <h2 class="main-nav-header">
-        <a id="main-nav-researchmenu-title" href="https://libraries.mit.edu/research-support" class="no-underline main-nav-link">Research support</a>
-        <button class="menu-control sr">Research support menu</button>
-      </h2>
-      <div aria-labelledby="main-nav-researchmenu-title" id="main-nav-researchmenu" class="links-sub flex-container push group">
-        <div class="col-1 flex-item">
-          <h3 class="heading-col">Help &amp; useful tools</h3>
-          <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
-            <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
-            <li><a href="https://libraries.mit.edu/offcampus">Connect from on and off-campus <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/productivity-tools">Productivity tools <span class="about">Apps, RSS, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/new-books">New books by subject <span class="about">Browse or subscribe to RSS feeds</span></a></li>
-            <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
-          </ul>
-        </div>
-        <div class="col-2 flex-item">
-          <h3 class="heading-col">Publishing &amp; content management</h3>
-          <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
-            <li><a href="https://libraries.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-            <li><a href="https://libraries.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
-            <li><a href="https://libraries.mit.edu/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>
-          </ul>
-        </div>
-      </div><!-- end div.links-sub -->
-    </li><!-- end div.links-primary -->
-    <li class="link-primary flex-end">
-      <h2 class="main-nav-header">
-        <a id="main-nav-aboutmenu-title" href="https://libraries.mit.edu/about" class="no-underline main-nav-link">About</a>
-        <button class="menu-control sr">About menu</button>
-      </h2>
-      <div aria-labelledby="main-nav-aboutmenu-title" id="main-nav-aboutmenu" class="links-sub flex-container push group">
-        <div class="col-1 flex-item">
-          <h3 class="heading-col">About the Libraries</h3>
-          <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/about/">About us</a></li>
-            <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
-            <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>
-            <li><a href="https://libraries.mit.edu/giving">Giving to the MIT Libraries</a></li>
-          </ul>
-        </div>
-        <div class="col-2 flex-item">
-          <h3 class="heading-col">News, events, &amp; exhibits</h3>
-          <a href="https://libraries.mit.edu/events">Classes &amp; events</a>
-          <a href="https://libraries.mit.edu/news">News</a>
-          <a href="https://libraries.mit.edu/exhibits">Exhibits &amp; galleries</a>
-          <a href="https://libraries.mit.edu/news/in-the-media">In the media</a>
-          <a href="https://libraries.mit.edu/mit-reads/">MIT Reads</a>
-        </div>
-      </div><!-- end div.links-sub -->
-    </li><!-- end div.links-primary -->
-    <li class="link-primary flex-end small chat push">
-      <h2 class="main-nav-header">
-        <a id="main-nav-askusmenu-title" href="https://libraries.mit.edu/ask" class="no-underline main-nav-link"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="16.593px" height="16px" viewBox="0 0 16.593 16" enable-background="new 0 0 16.593 16" xml:space="preserve"><path d="M16.593 6.278c0 1.074-0.074 2.148-0.241 3.185 -0.204 1.353-1.722 2.574-3.055 2.722 -1.353 0.131-2.686 0.204-4.02 0.223L5.74 15.833C5.63 15.944 5.481 16 5.334 16c-0.094 0-0.167-0.019-0.241-0.037C4.871 15.87 4.74 15.647 4.74 15.407V12.37c-0.481-0.036-0.963-0.055-1.443-0.111 -1.334-0.148-2.853-1.443-3.074-2.796C0.074 8.426 0 7.352 0 6.296c0-1.092 0.074-2.185 0.223-3.24 0.222-1.352 1.74-2.648 3.074-2.797C4.963 0.093 6.63 0 8.297 0s3.333 0.093 5 0.259c1.333 0.149 2.851 1.445 3.055 2.797C16.519 4.111 16.593 5.204 16.593 6.278"/></svg><span>Ask Us</span></a>
-        <button class="menu-control sr">Ask us menu</button>
-      </h2>
-      <div aria-labelledby="main-nav-askusmenu-title" id="main-nav-askusmenu" class="links-sub push">
-        <div class="wrap-button-chat">
-        <div id='libchat_be2c654b63dd43f31c56295ee5d78d88'></div>
-        </div>
-        <a class="more" href="https://libraries.mit.edu/ask">More ways to ask us</a>
-      </div>
-    </li>
-    <li class="link-primary flex-end small">
-      <h2 class="main-nav-header">
-        <a href="https://libraries.mit.edu/barton-account" class="no-underline main-nav-link account-link">
-          <svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="15.4" height="16" viewBox="0 0 15.4 16" enable-background="new 0 0 15.445 16" xml:space="preserve"><path d="M13.4 15.7C12.2 15.9 10.4 16 7.7 16c-5.4 0-7.3-0.6-7.3-0.6 -0.3-0.1-0.4-0.4-0.4-0.7 0.3-1.6 1.2-2.5 2.5-3.3 0.3-0.2 0.8-0.4 1.2-0.6 0.8-0.3 1.8-0.7 2-1.3C5.8 9.2 5.7 8.6 5.2 7.9c-1.4-2.3-1.7-4.3-0.8-5.9C5.1 0.7 6.4 0 7.7 0c1.4 0 2.6 0.7 3.3 2 0.9 1.6 0.7 3.6-0.8 5.9C9.8 8.6 9.6 9.2 9.8 9.6c0.2 0.6 1.2 1 2 1.3 0.4 0.2 0.9 0.4 1.2 0.6 1.2 0.8 2.1 1.6 2.5 3.3 0.1 0.3-0.1 0.6-0.4 0.7C15 15.4 14.5 15.6 13.4 15.7"/></svg><span>Account</span>
-        </a>
-      </h2>
-    </li>
-  </ul>
+  <nav id="nav-main" class="nav-main flex-container" aria-label="Primary">
+    <ul class="nav-main-list flex-end">
+      <li class="link-primary flex-end">
+        <h2 class="main-nav-header">
+          <a id="main-nav-privacy-title" href="https://libraries.mit.edu/privacy" class="no-underline main-nav-link">Privacy</a>
+        </h2>
+      </li>
+      <li class="flex-end"><h2 class="main-nav-divider"> | </h2></li>
+      <li class="link-primary flex-end">
+        <h2 class="main-nav-header">
+          <a id="main-nav-accessibility-title" href="https://libraries.mit.edu/accessibility" class="no-underline main-nav-link">Accessibility</a>
+        </h2>
+      </li>
+    </ul>
+    <a class="link-logo-mit flex-end" href="http://www.mit.edu"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"/><rect width="5.8" height="28"/><rect x="9.6" width="5.8" height="18.8"/><rect x="19.3" width="5.8" height="28"/><rect x="38.5" y="8.9" width="5.8" height="19.1"/><rect x="38.8" width="15.2" height="5.6"/><rect x="28.9" width="5.8" height="5.6"/></svg></a>
   </nav>
-  <a class="link-logo-mit" href="http://www.mit.edu"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"/><rect width="5.8" height="28"/><rect x="9.6" width="5.8" height="18.8"/><rect x="19.3" width="5.8" height="28"/><rect x="38.5" y="8.9" width="5.8" height="19.1"/><rect x="38.8" width="15.2" height="5.6"/><rect x="28.9" width="5.8" height="5.6"/></svg></a>
-  <a href="https://libraries.mit.edu/search" class="link-site-search hidden-non-mobile">
-    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="12" height="16" viewBox="0 0 12 12" alt="search" class="icon-search"><path d="M7.273 0.727q1.187 0 2.19 0.585t1.588 1.588 0.585 2.19-0.585 2.19-1.588 1.588-2.19 0.585q-1.278 0-2.33-0.676l-3.284 3.301q-0.295 0.284-0.688 0.284-0.403 0-0.688-0.284t-0.284-0.688 0.284-0.688l3.301-3.284q-0.676-1.051-0.676-2.33 0-1.188 0.585-2.19t1.588-1.588 2.19-0.585zM7.273 8q0.591 0 1.128-0.23t0.929-0.622 0.622-0.929 0.23-1.128-0.23-1.128-0.622-0.929-0.929-0.622-1.128-0.23-1.128 0.23-0.929 0.622-0.622 0.929-0.23 1.128 0.23 1.128 0.622 0.929 0.929 0.622 1.128 0.23z"></path>
-    </svg>
-    <span class="bottom">Search</span>
-  </a>
-  <a href="https://libraries.mit.edu/barton-account" class="link-account hidden-non-mobile">
-    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="15.4" height="16" viewBox="0 0 15.4 16" enable-background="new 0 0 15.445 16" xml:space="preserve" class="icon-account"><path d="M13.4 15.7C12.2 15.9 10.4 16 7.7 16c-5.4 0-7.3-0.6-7.3-0.6 -0.3-0.1-0.4-0.4-0.4-0.7 0.3-1.6 1.2-2.5 2.5-3.3 0.3-0.2 0.8-0.4 1.2-0.6 0.8-0.3 1.8-0.7 2-1.3C5.8 9.2 5.7 8.6 5.2 7.9c-1.4-2.3-1.7-4.3-0.8-5.9C5.1 0.7 6.4 0 7.7 0c1.4 0 2.6 0.7 3.3 2 0.9 1.6 0.7 3.6-0.8 5.9C9.8 8.6 9.6 9.2 9.8 9.6c0.2 0.6 1.2 1 2 1.3 0.4 0.2 0.9 0.4 1.2 0.6 1.2 0.8 2.1 1.6 2.5 3.3 0.1 0.3-0.1 0.6-0.4 0.7C15 15.4 14.5 15.6 13.4 15.7"/></svg>
-    <span class="bottom">Account</span>
-  </a>
-
 </header>


### PR DESCRIPTION
This updates the LibWizard header, as described here: https://mitlibraries.atlassian.net/browse/UXWS-1034

Tl;dr, the previous version of the LibWizard header had non-functioning drop-down menus, and it does not support footers. To fix both of these problems, UXWS suggested an extra-slim header specifically for LibWizard that links to the privacy and accessibility pages.

As part of this work, I tried to clean up the custom header and CSS a bit (e.g., removing some JS that isn't called, removing the CSS for the nonexistent footer, etc). There is probably more cleanup to be done, but I'm somewhat concerned about accidentally breaking things, as it was something of a balancing act to get to this point.

Unfortunately, there is no staging area for LibWizard, so there's no live version to view. Screenshots of desktop and mobile viewports are below:

![libwiz-fs](https://user-images.githubusercontent.com/16103405/96492812-30a89d00-1212-11eb-9e92-e4ca4af6ea22.png)
![libwiz-iphone](https://user-images.githubusercontent.com/16103405/96492818-32726080-1212-11eb-9666-bb9f9658e2c1.png)
