### PR TITLE
Add left margin to MIT logo

### DIFF
--- a/libwizard/custom-head.html
+++ b/libwizard/custom-head.html
@@ -130,13 +130,16 @@ h3 {
   }
 }
 
+@media only screen and (min-width:569px) {
+  .header-main .link-logo-mit {
+    margin-left: 2rem;
+  }
+}
+
 .header-main .link-logo-mit {
   max-width: 59px;
   max-width: 59px;
   max-width: 3.6875rem;
-}
-
-.header-main .link-logo-mit {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;


### PR DESCRIPTION
This is a small tweak to #31 that Stephanie requested. The changes are live here: https://mit.libwizard.com/f/music-parts

Related Jira ticket: https://mitlibraries.atlassian.net/browse/UXWS-1034