### PR TITLE
Implement header changes for libguides, libcal, and libanswers

### DIFF
--- a/libanswers/custom-header.html
+++ b/libanswers/custom-header.html
@@ -25,18 +25,15 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Start here</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
-            <li><a href="https://libraries.mit.edu/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Classic catalog search</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Books, articles, and more</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton-reserves">Course reserves</a></li>
+            <li><a href="https://libraries.mit.edu/search-reserves">Course reserves</a></li>
             <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
           <h3 class="heading-col">Also try</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
             <li><a href="https://libraries.mit.edu/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
             <li><a href="https://libraries.mit.edu/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
             <li><a href="https://libraries.mit.edu/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
@@ -87,8 +84,8 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/barton-account">Your Account - Barton <span class="about">Renew MIT items</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Your Account, ILLiad, Aeon, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Request items owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
@@ -98,7 +95,6 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Barton, ILLiad, Aeon, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP</a></li>
             <li><a href="https://libraries.mit.edu/borrow-direct">Borrow Direct <span class="about">Request items from Harvard, Yale, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>
@@ -118,7 +114,6 @@
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/authenticate">Authenticate to online resources <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/new-books">New books by subject <span class="about">Browse or subscribe to RSS feeds</span></a></li>
             <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>
         </div>

--- a/libanswers/custom-header.html
+++ b/libanswers/custom-header.html
@@ -122,8 +122,7 @@
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
             <li><a href="https://libraries.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-            <li><a href="https://libraries.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
+            <li><a href="https://libraries.mit.edu/data-services">Data services <span class="about">GIS, data management, statistical support</span></a></li>
             <li><a href="https://libraries.mit.edu/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>
             <li><a href="https://libraries.mit.edu/apis">APIs for scholarly resources</a></li>
           </ul>

--- a/libanswers/custom-header.html
+++ b/libanswers/custom-header.html
@@ -25,10 +25,10 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Start here</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/search">Search tools home</a></li>
             <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Books, articles, and more</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/search-reserves">Course reserves</a></li>
-            <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -51,6 +51,7 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Locations</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/hours">Hours and locations home</a></li>
             <li><a href="https://libraries.mit.edu/barker">Barker Library</a></li>
             <li><a href="https://libraries.mit.edu/dewey">Dewey Library</a></li>
             <li><a href="https://libraries.mit.edu/hayden">Hayden Library</a></li>
@@ -58,7 +59,6 @@
             <li><a href="https://libraries.mit.edu/distinctive-collections">Distinctive Collections</a></li>
             <li><a href="https://libraries.mit.edu/music">Lewis Music Library</a></li>
             <li><a href="https://libraries.mit.edu/lsa">Library Storage Annex</a></li>
-            <li><a href="https://libraries.mit.edu/hours" class="bottom">All hours &amp; locations</a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -84,12 +84,12 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/borrow">Borrow &amp; request home</a></li>
             <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Your Account, ILLiad, Aeon, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Request items owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
-            <li><a href="https://libraries.mit.edu/borrow" class="bottom">More options &amp; help</a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -111,10 +111,10 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Help &amp; useful tools</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/research-support">Research support home</a></li>
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/authenticate">Authenticate to online resources <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -138,7 +138,7 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">About the Libraries</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/about/">About us</a></li>
+            <li><a href="https://libraries.mit.edu/about/">About us home</a></li>
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
             <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>
             <li><a href="https://libraries.mit.edu/giving">Giving to the MIT Libraries</a></li>

--- a/libanswers/custom-header.html
+++ b/libanswers/custom-header.html
@@ -26,7 +26,7 @@
           <h3 class="heading-col">Start here</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/search">Search tools home</a></li>
-            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Books, articles, and more</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search Our Collections <span class="about">Books, articles, and more</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/search-reserves">Course reserves</a></li>
           </ul>
@@ -86,7 +86,7 @@
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/borrow">Borrow &amp; request home</a></li>
             <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Your Account, ILLiad, Aeon, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search Our Collections <span class="about">Request items owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>

--- a/libcal/custom-header.html
+++ b/libcal/custom-header.html
@@ -25,18 +25,15 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Start here</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
-            <li><a href="https://libraries.mit.edu/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Classic catalog search</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Books, articles, and more</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton-reserves">Course reserves</a></li>
+            <li><a href="https://libraries.mit.edu/search-reserves">Course reserves</a></li>
             <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
           <h3 class="heading-col">Also try</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
             <li><a href="https://libraries.mit.edu/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
             <li><a href="https://libraries.mit.edu/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
             <li><a href="https://libraries.mit.edu/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
@@ -87,8 +84,8 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/barton-account">Your Account - Barton <span class="about">Renew MIT items</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Your Account, ILLiad, Aeon, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Request items owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
@@ -98,7 +95,6 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Barton, ILLiad, Aeon, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP</a></li>
             <li><a href="https://libraries.mit.edu/borrow-direct">Borrow Direct <span class="about">Request items from Harvard, Yale, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>
@@ -118,7 +114,6 @@
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/authenticate">Authenticate to online resources <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/new-books">New books by subject <span class="about">Browse or subscribe to RSS feeds</span></a></li>
             <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>
         </div>

--- a/libcal/custom-header.html
+++ b/libcal/custom-header.html
@@ -122,8 +122,7 @@
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
             <li><a href="https://libraries.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-            <li><a href="https://libraries.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
+            <li><a href="https://libraries.mit.edu/data-services">Data services <span class="about">GIS, data management, statistical support</span></a></li>
             <li><a href="https://libraries.mit.edu/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>
             <li><a href="https://libraries.mit.edu/apis">APIs for scholarly resources</a></li>
           </ul>

--- a/libcal/custom-header.html
+++ b/libcal/custom-header.html
@@ -25,10 +25,10 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Start here</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/search">Search tools home</a></li>
             <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Books, articles, and more</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/search-reserves">Course reserves</a></li>
-            <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -51,6 +51,7 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Locations</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/hours">Hours and locations home</a></li>
             <li><a href="https://libraries.mit.edu/barker">Barker Library</a></li>
             <li><a href="https://libraries.mit.edu/dewey">Dewey Library</a></li>
             <li><a href="https://libraries.mit.edu/hayden">Hayden Library</a></li>
@@ -58,7 +59,6 @@
             <li><a href="https://libraries.mit.edu/distinctive-collections">Distinctive Collections</a></li>
             <li><a href="https://libraries.mit.edu/music">Lewis Music Library</a></li>
             <li><a href="https://libraries.mit.edu/lsa">Library Storage Annex</a></li>
-            <li><a href="https://libraries.mit.edu/hours" class="bottom">All hours &amp; locations</a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -84,12 +84,12 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/borrow">Borrow &amp; request home</a></li>
             <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Your Account, ILLiad, Aeon, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Request items owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
-            <li><a href="https://libraries.mit.edu/borrow" class="bottom">More options &amp; help</a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -111,10 +111,10 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Help &amp; useful tools</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/research-support">Research support home</a></li>
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/authenticate">Authenticate to online resources <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -138,7 +138,7 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">About the Libraries</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/about/">About us</a></li>
+            <li><a href="https://libraries.mit.edu/about/">About us home</a></li>
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
             <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>
             <li><a href="https://libraries.mit.edu/giving">Giving to the MIT Libraries</a></li>

--- a/libcal/custom-header.html
+++ b/libcal/custom-header.html
@@ -26,7 +26,7 @@
           <h3 class="heading-col">Start here</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/search">Search tools home</a></li>
-            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Books, articles, and more</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search Our Collections <span class="about">Books, articles, and more</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/search-reserves">Course reserves</a></li>
           </ul>
@@ -86,7 +86,7 @@
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/borrow">Borrow &amp; request home</a></li>
             <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Your Account, ILLiad, Aeon, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search Our Collections <span class="about">Request items owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -134,8 +134,7 @@
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
             <li><a href="https://libraries.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-            <li><a href="https://libraries.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
+            <li><a href="https://libraries.mit.edu/data-services">Data services <span class="about">GIS, data management, statistical support</span></a></li>
             <li><a href="https://libraries.mit.edu/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>
             <li><a href="https://libraries.mit.edu/apis">APIs for scholarly resources</a></li>
           </ul>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -37,10 +37,10 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Start here</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/search">Search tools home</a></li>
             <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Books, articles, and more</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/search-reserves">Course reserves</a></li>
-            <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -63,6 +63,7 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Locations</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/hours">Hours and locations home</a></li>
             <li><a href="https://libraries.mit.edu/barker">Barker Library</a></li>
             <li><a href="https://libraries.mit.edu/dewey">Dewey Library</a></li>
             <li><a href="https://libraries.mit.edu/hayden">Hayden Library</a></li>
@@ -70,7 +71,6 @@
             <li><a href="https://libraries.mit.edu/distinctive-collections">Distinctive Collections</a></li>
             <li><a href="https://libraries.mit.edu/music">Lewis Music Library</a></li>
             <li><a href="https://libraries.mit.edu/lsa">Library Storage Annex</a></li>
-            <li><a href="https://libraries.mit.edu/hours" class="bottom">All hours &amp; locations</a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -96,12 +96,12 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/borrow">Borrow &amp; request home</a></li>
             <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Your Account, ILLiad, Aeon, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Request items owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
-            <li><a href="https://libraries.mit.edu/borrow" class="bottom">More options &amp; help</a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -123,10 +123,10 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Help &amp; useful tools</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/research-support">Research support home</a></li>
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/authenticate">Authenticate to online resources <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
@@ -150,7 +150,7 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">About the Libraries</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/about/">About us</a></li>
+            <li><a href="https://libraries.mit.edu/about/">About us home</a></li>
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
             <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>
             <li><a href="https://libraries.mit.edu/giving">Giving to the MIT Libraries</a></li>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -38,7 +38,7 @@
           <h3 class="heading-col">Start here</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/search">Search tools home</a></li>
-            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Books, articles, and more</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search Our Collections <span class="about">Books, articles, and more</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/search-reserves">Course reserves</a></li>
           </ul>
@@ -98,7 +98,7 @@
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/borrow">Borrow &amp; request home</a></li>
             <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Your Account, ILLiad, Aeon, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search Our Collections <span class="about">Request items owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -37,18 +37,15 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Start here</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
-            <li><a href="https://libraries.mit.edu/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Classic catalog search</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Books, articles, and more</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton-reserves">Course reserves</a></li>
+            <li><a href="https://libraries.mit.edu/search-reserves">Course reserves</a></li>
             <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
         </div>
         <div class="col-2 flex-item">
           <h3 class="heading-col">Also try</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
             <li><a href="https://libraries.mit.edu/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
             <li><a href="https://libraries.mit.edu/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
             <li><a href="https://libraries.mit.edu/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
@@ -99,8 +96,8 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/barton-account">Your Account - Barton <span class="about">Renew MIT items</span></a></li>
-            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Your Account, ILLiad, Aeon, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/search-collections">Search our collections <span class="about">Request items owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
@@ -110,7 +107,6 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/accounts">Accounts overview <span class="about">Barton, ILLiad, Aeon, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP</a></li>
             <li><a href="https://libraries.mit.edu/borrow-direct">Borrow Direct <span class="about">Request items from Harvard, Yale, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>
@@ -130,7 +126,6 @@
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/authenticate">Authenticate to online resources <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/new-books">New books by subject <span class="about">Browse or subscribe to RSS feeds</span></a></li>
             <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>
         </div>


### PR DESCRIPTION
This proposes a few different tickets' worth of changes. These changes are all being applied to three of our hosted properties:

1. LibGuides
2. LibCal
3. LibAnswers

### 1. Updates to support launch of Alma / Primo
- Ticket: https://mitlibraries.atlassian.net/browse/IMP-2188
- Mockup: https://zsnzw2.axshare.com/#id=g57afp&p=web_site_main_nav_edits&g=1

This implements the same changes that were made to WordPress in MITLibraries/MITlibraries-parent#340

### 2. Catching up to other changes to navigation
Tickets: 
- https://mitlibraries.atlassian.net/browse/UXWS-1136 (summary of catching up)
- https://mitlibraries.atlassian.net/browse/UXWS-943 (Research support changes)
- https://mitlibraries.atlassian.net/browse/NTI-570 (adding home links to submenus - other parts of this ticket are still undone)

A variety of changes have been made to the top navigation of libraries.mit.edu over the last year, not all of which have been ported over to our hosted platforms. While the complete set of updates may be beyond our bandwidth, a number of them can be incorporated into this change.

## To see these changes
These changes have been applied to the test group within LibGuides (see ticket IMP-2188 for link). There is no test group for libcal or libanswers, but the changes will be the same there.

Other hosted properties, and the footer to these three sites, will be unaffected by any of these changes.
