### PR TITLE
Adjust z-index of navbar to not sit atop a modal

### DIFF
--- a/libanswers-ddc/custom-head.html
+++ b/libanswers-ddc/custom-head.html
@@ -399,7 +399,7 @@ a:hover i {
   -webkit-transform: translateY(-1000%);
   -ms-transform: translateY(-1000%);
   transform: translateY(-1000%);
-  z-index: 7000;
+  z-index: 950;
   margin: 0;
   padding: 0;
   width: 0;
@@ -768,7 +768,7 @@ a:hover i {
   -ms-flex-order: 1;
   order: 1;
   width: 14.375%;
-  z-index: 7000
+  z-index: 950;
 }
 
 @media only screen and (min-width:569px) {

--- a/libanswers/custom-head.html
+++ b/libanswers/custom-head.html
@@ -399,7 +399,7 @@ a:hover i {
   -webkit-transform: translateY(-1000%);
   -ms-transform: translateY(-1000%);
   transform: translateY(-1000%);
-  z-index: 7000;
+  z-index: 950;
   margin: 0;
   padding: 0;
   width: 0;
@@ -768,7 +768,7 @@ a:hover i {
   -ms-flex-order: 1;
   order: 1;
   width: 14.375%;
-  z-index: 7000
+  z-index: 950;
 }
 
 @media only screen and (min-width:569px) {

--- a/libcal/custom-head.html
+++ b/libcal/custom-head.html
@@ -398,7 +398,7 @@ h3 {
   -webkit-transform: translateY(-1000%);
   -ms-transform: translateY(-1000%);
   transform: translateY(-1000%);
-  z-index: 7000;
+  z-index: 950;
   margin: 0;
   padding: 0;
   width: 0;
@@ -767,7 +767,7 @@ h3 {
   -ms-flex-order: 1;
   order: 1;
   width: 14.375%;
-  z-index: 7000
+  z-index: 950;
 }
 
 @media only screen and (min-width:569px) {

--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -401,7 +401,7 @@ h3 {
   -webkit-transform: translateY(-1000%);
   -ms-transform: translateY(-1000%);
   transform: translateY(-1000%);
-  z-index: 7000;
+  z-index: 950;
   margin: 0;
   padding: 0;
   width: 0;
@@ -770,7 +770,7 @@ h3 {
   -ms-flex-order: 1;
   order: 1;
   width: 14.375%;
-  z-index: 7000
+  z-index: 950;
 }
 
 @media only screen and (min-width:569px) {


### PR DESCRIPTION
#### Why are these changes being introduced:

* Springshare has a library providing a modal dialog on its platforms
  which uses a z-index value of 1000 (for the mask) and 1001 (for the
  actual modal dialog). This is meant to sit on top of everything, but
  our navbar currently uses the z-index value of 7000 - a value brought
  over from our WordPress themes, which use a broader spectrum of
  values.
  As a result, our navbar can conceal some modal elements, which causes
  usability problems.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/uxws-1232

#### How does this address that need:

* This drops the z-index value for the navbar from 7000 to 950. The
  change is made to four of the templates: Libguides, LibCal,
  LibAnswers, and DDC LibAnswers.

#### Document any side effects to this change:

* This is a difference between the WordPress styles and the Springshare
  styles, which is going to need to be respected through future style
  changes. Without a cross-context build system for our branding
  implementation, there isn't much we can do to mediate this other than
  "remember that this difference exists". It may be the the range of
  values on WordPress is motivated by existing values in _that_
  application, but I haven't verified this.