### PR TITLE
Add Matomo tracking code to LibGuides

### DIFF
--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -71,6 +71,7 @@ jQuery(document).ready(function($) {
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {

--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -67,6 +67,22 @@ jQuery(document).ready(function($) {
 });
 </script>
 
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://matomo.libraries.mit.edu/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '6']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
 <style type="text/css">
 /* Basic layout rules */
 * {

--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -71,7 +71,6 @@ jQuery(document).ready(function($) {
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {


### PR DESCRIPTION
#### Why these changes are being introduced:

We want to collect analytics data from LibGuides in Matomo.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/UXWS-1566

#### How this addresses that need:

This adds Matomo tracking code to the custom head for LibGuides. This is already in prod, and the markup in `libguides/custom-head.html` was copied and pasted directly from our LibGuides account.

#### Side effects of this change:

Not a side-effect, but a note that this data is compiled in the same property as the Libraries website.
