### PR TITLE
Add Matomo tracking code to LibGuides

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The 'Look & Feel' interface in LibApps has separate `textarea`
 elements in which you can paste the `header`, `footer`, and `head` code.
 Note that the corresponding box for `head` is usually labelled 'Custom JS/CSS'.
 
+The LibGuides directory also includes `custom-analytics.html`, which can be found in the 'Custom Analytics' tab of
+'System Settings'. This is currently Google Analytics tracking code, which we are running alongside Matomo (in
+`custom-head.html`) for QA purposes. Once we are satisfied that the Matomo data replicates our GA data, we will remove
+the GA code and move the Matomo code to `Custom Analytics`.
+
 For Aeon and ArchivesSpace, the files must be emailed to staff at Atlas and
 Lyrasis respectively for placing on their servers.
 

--- a/libguides/custom-analytics.html
+++ b/libguides/custom-analytics.html
@@ -1,0 +1,11 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-1760176-1',  'auto', {'allowLinker': true});
+  ga('require', 'linker');
+  ga('linker:autoLink', ['libguides.mit.edu', 'libcal.mit.edu', 'libanswers.mit.edu'] );
+  ga('send', 'pageview');
+</script>

--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -67,6 +67,22 @@ jQuery(document).ready(function($) {
 });
 </script>
 
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://matomo.libraries.mit.edu/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '6']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
 <style type="text/css">
 /* Basic layout rules */
 * {


### PR DESCRIPTION
#### Why these changes are being introduced:

We want to collect analytics data from LibGuides in Matomo.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/UXWS-1566

#### How this addresses that need:

This adds Matomo tracking code to the custom head for LibGuides. This is already in prod, and the markup in `libguides/custom-head.html` was copied and pasted directly from our LibGuides account.

#### Side effects of this change:

* GA code is currently loaded in the "Custom Analytics" section of LibGuides system settings. UXWS would like us to continue running GA and Matomo together for QA purposes, so I've checked in a custom analytics file and noted in the readme that we should move Matomo to it once we're satisfied with the quality of the Matomo data.
* Not a side-effect, but a note that this data is compiled in the same property as the Libraries website.