### PR TITLE
Styling updates for A-Z Databases redesign

### DIFF
--- a/libguides/custom-footer-js-az.html
+++ b/libguides/custom-footer-js-az.html
@@ -1,0 +1,9 @@
+<script src="//v2.libanswers.com/load_chat.php?hash=be2c654b63dd43f31c56295ee5d78d88"></script>
+
+<!-- Replace placeholders for search input -->
+<script>
+const placeholder = document.querySelector('div#s-lg-az-filter-cols input.s-lg-az-search');
+const mobilePlaceholder = document.querySelector('div#az-public-mobile-filters input.s-lg-az-search');
+placeholder.setAttribute('placeholder', 'Keyword');
+mobilePlaceholder.setAttribute('placeholder', 'Keyword');
+</script>

--- a/libguides/custom-footer.html
+++ b/libguides/custom-footer.html
@@ -20,4 +20,3 @@
     </div><!-- end .footer-info-institute -->
 </div>
 </footer>
-<script src="//v2.libanswers.com/load_chat.php?hash=be2c654b63dd43f31c56295ee5d78d88"></script>

--- a/libguides/custom-head-az.html
+++ b/libguides/custom-head-az.html
@@ -12,65 +12,6 @@
 <!--meta tag to scale mobile device display-->
 <meta name="viewport" content="width=device-width, maximum-scale=1">
 
-<script type="text/javascript">
-jQuery(document).ready(function($) {
-  jQuery("img[alt='null'], img[alt='Null'], img[alt='NULL']").attr("alt", "");
-  var libchat_efc75c55947db323d4faab725b79307f = { iid:59, key:'fb10446730e271c', width:'240' };
-
-  $('header .menu--toggle').click(function(){
-    $('#nav-main').toggleClass('active');
-    $('.wrap-page').toggleClass('mobile-nav-active');
-  });
-
-  $( '.link-primary' ).bind( "mouseenter", function() { 
-    $( '.link-primary' ).removeClass( 'open' );
-    $(this).find( '.menu-control' ).attr( 'aria-expanded', 'true' );
-    $(this).closest( '.link-primary' ).addClass( 'open' );
-  });
-  $( '.link-primary' ).bind( "mouseleave", function() { 
-    $(this).find( '.menu-control' ).attr( 'aria-expanded', 'false' );
-    $( '.link-primary' ).removeClass( 'open' );
-  });
-
-  // make esc close all menus
-  $( '#nav-main' ).on( 'keydown' , function(e) {
-    if (e.keyCode == 27) {
-      hideMenu(e);
-    }
-  });
-
-  function hideMenu() {
-    $( '.link-primary' ).removeClass( 'open' );
-    $( '.menu-control' ).attr('aria-expanded', 'false');
-    $( '.links-sub' ).attr( 'aria-hidden', 'true' );
-  }
-
-  // thanks to http://heydonworks.com/practical_aria_examples/
-  $('.main-nav-header').each(function() {
-
-    var $this = $(this);
-
-    // create unique id for a11y relationship
-    var id = 'collapsible-' + $( '#nav-main h2' ).index(this);
-
-    // identify panel and make it focusable
-    var panel = $(this).next( '.links-sub' ).attr( 'aria-hidden', 'true' ).attr( 'id', id);
-
-    // Add default aria states to button
-    $this.children( '.menu-control' ).attr( 'aria-expanded', 'false' ).attr( 'aria-controls', id);
-    var button = $this.children( '.menu-control' );
-
-    // Toggle the state properties
-    button.on( 'click', function() {
-      $(this).closest( '.link-primary' ).toggleClass( 'open' );
-      var state = $(this).attr( 'aria-expanded' ) === 'false' ? true : false;
-      $(this).attr( 'aria-expanded', state );
-      panel.attr( 'aria-hidden', !state );
-    });
-  });
-});
-</script>
-
 <style type="text/css">
 /* Basic layout rules */
 * {
@@ -137,7 +78,7 @@ h3 {
 /* 1. Header & Nav */
 .header-main {
   position: relative;
-  background: #000 url('https://libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 0 65%;
+  background: #000 url('https://cdn.libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 0 65%;
   clear: both;
   width: 100%;
 }
@@ -811,7 +752,7 @@ body.user-is-tabbing *.nav-main .main-nav-link.no-underline:focus {
 
 /* 2. Footer */
 .footer-main {
-  background: #000 url(../../images/vi-shape7-tp.png) no-repeat 10% center;
+  background: #000 url('https://cdn.libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 10% center;
   flex-wrap: wrap;
   clear: both;
   width: 100%;
@@ -1124,7 +1065,6 @@ body.user-is-tabbing *.nav-main .main-nav-link.no-underline:focus {
 /* Reset only what you need */
 .header-main,
 footer {
-  max-width: 1170px; /* matches .container */
   width: 100%;
   margin: 0 auto;
 }
@@ -1191,15 +1131,6 @@ footer {
   }
   .header-main .link-logo-mit {
     display: none
-  }
-}
-
-/* 635px is the maximum width before the logos will shrink if both are displayed */
-@media only screen and (min-width: 635px) {
-  .header-main .link-logo-mit {
-    display: block;
-    padding: 20px 0;
-    vertical-align: baseline;
   }
 }
 
@@ -1319,11 +1250,11 @@ table, th, td {
 /* Overriding the accordion markup with changeable arrows */
 .accordion-group .accordion-toggle {
   margin-left: 0px;
-  background: url('https://libraries.mit.edu/images/libguides-arrow-down.png') no-repeat left center;
+  background: url('https://cdn.libraries.mit.edu/images/libguides-arrow-down.png') no-repeat left center;
   padding-left: 15px;
 }
 .accordion-group .accordion-toggle.collapsed {
-  background-image: url('https://libraries.mit.edu/images/libguides-arrow-right.png')
+  background-image: url('https://cdn.libraries.mit.edu/images/libguides-arrow-right.png')
 }
 
 /* BartonPlus search box */
@@ -1423,5 +1354,144 @@ height:auto;
 .alert-banner .fa {
   display: inline-block;
   margin-right: 0.5em;
+}
+</style>
+
+<!-- Styling for the A-Z Databases 2024 UI redesign -->
+<style>
+/* NOTE: At some point, LibGuides and the new A-Z Databases will share a 'Look and Feel' template, as they do with
+  the old A-Z Databases. This CSS should be reevaluated then to ensure that both properties look as expected. */
+#s-lg-az-trials {
+  background-color: #e4e4e4;
+}
+
+#s-lg-az-trials .az-description {
+  color: #000;
+}
+
+#s-lib-public-header-title {
+  margin-bottom: .5rem;
+}
+
+#s-lg-az-filter-cols div.row>div,
+#s-lg-az-filter-cols div.row>div:last-child {
+  border: 1px solid #c7ccd1;
+  border-radius: .5em;
+  margin-right: 1em;
+}
+
+#s-lg-az-filter-cols div.row>div:first-child {
+  margin-left: 1em;
+}
+
+#col-search input,
+.col-subjects input,
+.col-types input,
+.col-vendors input,
+#col-search input::placeholder,
+.col-subjects textarea::placeholder,
+.col-types textarea::placeholder,
+.col-vendors textarea::placeholder {
+  font-size: 1rem!important;
+}
+
+#az-public-mobile-filters input,
+.select2-results__option,
+.select2-results__options,
+#az-public-mobile-filters .select2-selection__choice,
+#s-lg-az-filters .select2-selection__choice,
+.select2-container--bootstrap5 .select2-search.select2-search--inline .select2-search__field,
+#az-public-mobile-filters input::placeholder,
+.select2-container--bootstrap5 .select2-search.select2-search--inline .select2-search__field::placeholder {
+  font-size: 1rem;
+}
+
+button[data-bs-dismiss="modal"] {
+  background-color: #c6c7c8;
+}
+
+#s-lg-az-index button.s-lg-az-header:hover,
+#s-lg-az-index button.s-lg-az-header:focus {
+  text-decoration: underline;
+}
+
+.az-configured-fields-label,
+.az-configured-fields-value {
+  font-family: Helvetica, "Open Sans", sans-serif;
+  font-size: 1rem;
+  color: #000;
+}
+
+.nav-main .main-nav-header {
+  font-weight: 500;
+}
+
+/* The rules below accommodate different Bootstrap versions in LibGuides and the new A-Z Databases.
+
+LibGuides currently uses Bootstrap 3, which has the following breakpoints:
+- min-width: 1200px (max-width: 1170px)
+- min-width: 992px (max-width: 970px)
+- min-width: 768px (max-width: 750px)
+
+The new A-Z uses Bootstrap 5, which has different breakpoints:
+- min-width: 1400px (max-width: 1320px),
+- min-width: 1200px (max-width: 1140px),
+- min-width: 992px (max-width: 960px),
+- min-width: 768px (max-width: 720px),
+- min-wifdth: 576px (max-width: 540px)
+
+Springshare has indicated that the same customizations will soon apply both to LibGuides and A-Z Databases, which would
+cause a conflict. However, they also plan to move LibGuides to Bootstrap 5, which they will hopefully do before
+collapsing the customizations. We are awaiting clarification on this. */
+@media only screen and (min-width: 576px) {
+  .header-main,
+  footer {
+    max-width: 540px; /* matches .container */
+    width: 100%;
+    margin: 0 auto;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .header-main,
+  footer {
+    max-width: 720px; /* matches .container */
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  /* This rule was previously set at a min-width of 635px for Bootstrap 3 */
+  .header-main .link-logo-mit {
+    display: block;
+    padding: 20px 0;
+    vertical-align: baseline;
+  }
+}
+
+@media only screen and (min-width: 992px) {
+  .header-main,
+  footer {
+    max-width: 960px; /* matches .container */
+    width: 100%;
+    margin: 0 auto;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .header-main,
+  footer {
+    max-width: 1140px; /* matches .container */
+    width: 100%;
+    margin: 0 auto;
+  }
+}
+
+@media only screen and (min-width: 1400px) {
+  .header-main,
+  footer {
+    max-width: 1320px; /* matches .container */
+    width: 100%;
+    margin: 0 auto;
+  }
 }
 </style>

--- a/libguides/custom-head-az.html
+++ b/libguides/custom-head-az.html
@@ -1,0 +1,1427 @@
+<!-- load favicons for miscellaneous platforms -->
+<link rel="icon" href="https://cdn.libraries.mit.edu/files/branding/favicons/favicon.ico" sizes="32x32">
+<link rel="icon" href="https://cdn.libraries.mit.edu/files/branding/favicons/favicon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="https://cdn.libraries.mit.edu/files/branding/favicons/apple-touch-icon.png"><!-- 180×180 -->
+<link rel="manifest" href="https://cdn.libraries.mit.edu/files/branding/favicons/manifest.json">
+
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,400italic,600,600italic,700,700italic">
+
+<!--added by Darcy to confirm w/ Google webmaster tools we own this site-->
+<meta name="google-site-verification" content="82Cv3HFWvcefC_9XauvglcfB4h3o0uuiC3nKWWkL_eE" />
+
+<!--meta tag to scale mobile device display-->
+<meta name="viewport" content="width=device-width, maximum-scale=1">
+
+<script type="text/javascript">
+jQuery(document).ready(function($) {
+  jQuery("img[alt='null'], img[alt='Null'], img[alt='NULL']").attr("alt", "");
+  var libchat_efc75c55947db323d4faab725b79307f = { iid:59, key:'fb10446730e271c', width:'240' };
+
+  $('header .menu--toggle').click(function(){
+    $('#nav-main').toggleClass('active');
+    $('.wrap-page').toggleClass('mobile-nav-active');
+  });
+
+  $( '.link-primary' ).bind( "mouseenter", function() { 
+    $( '.link-primary' ).removeClass( 'open' );
+    $(this).find( '.menu-control' ).attr( 'aria-expanded', 'true' );
+    $(this).closest( '.link-primary' ).addClass( 'open' );
+  });
+  $( '.link-primary' ).bind( "mouseleave", function() { 
+    $(this).find( '.menu-control' ).attr( 'aria-expanded', 'false' );
+    $( '.link-primary' ).removeClass( 'open' );
+  });
+
+  // make esc close all menus
+  $( '#nav-main' ).on( 'keydown' , function(e) {
+    if (e.keyCode == 27) {
+      hideMenu(e);
+    }
+  });
+
+  function hideMenu() {
+    $( '.link-primary' ).removeClass( 'open' );
+    $( '.menu-control' ).attr('aria-expanded', 'false');
+    $( '.links-sub' ).attr( 'aria-hidden', 'true' );
+  }
+
+  // thanks to http://heydonworks.com/practical_aria_examples/
+  $('.main-nav-header').each(function() {
+
+    var $this = $(this);
+
+    // create unique id for a11y relationship
+    var id = 'collapsible-' + $( '#nav-main h2' ).index(this);
+
+    // identify panel and make it focusable
+    var panel = $(this).next( '.links-sub' ).attr( 'aria-hidden', 'true' ).attr( 'id', id);
+
+    // Add default aria states to button
+    $this.children( '.menu-control' ).attr( 'aria-expanded', 'false' ).attr( 'aria-controls', id);
+    var button = $this.children( '.menu-control' );
+
+    // Toggle the state properties
+    button.on( 'click', function() {
+      $(this).closest( '.link-primary' ).toggleClass( 'open' );
+      var state = $(this).attr( 'aria-expanded' ) === 'false' ? true : false;
+      $(this).attr( 'aria-expanded', state );
+      panel.attr( 'aria-hidden', !state );
+    });
+  });
+});
+</script>
+
+<style type="text/css">
+/* Basic layout rules */
+* {
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+}
+
+body {
+  font-family: Helvetica, "Open Sans", sans-serif;
+  font-size: 16px; /* was 100%; */
+  line-height: 1.4;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  text-decoration: underline;
+  color: #000;
+}
+a:hover {
+  color: #00f;
+}
+
+h3 {
+  font-size: 20px;
+}
+
+.flex-container {
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.flex-end {
+  -webkit-box-align: end;
+  -webkit-align-items: flex-end;
+  -ms-flex-align: end;
+  align-items: flex-end;
+}
+
+.sr {
+  border: 0 none;
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  word-wrap: normal;
+}
+
+.list-unbulleted {
+  list-style: none;
+  padding-left: 0;
+  text-indent: 0;
+}
+
+/* Numbered sections below extracted from generated, unminified parent theme global.css */
+
+/* 1. Header & Nav */
+.header-main {
+  position: relative;
+  background: #000 url('https://libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 0 65%;
+  clear: both;
+  width: 100%;
+}
+@media only screen and (min-width: 569px) {
+  .header-main {
+    width: 100%;
+  }
+}
+@media only screen and (min-width: 569px) {
+  .header-main {
+    justify-content: space-between;
+    padding: 0 1em;
+  }
+}
+.header-main .name-site {
+  order: 2;
+  min-width: 77px;
+  min-width: 4.8125rem;
+  padding-bottom: 6.4px;
+  padding-bottom: 0.4rem;
+  font-size: 14.4px;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+@media only screen and (min-width: 569px) {
+  .header-main .name-site {
+    max-width: 104px;
+    max-width: 6.5rem;
+    margin-left: 1.5%;
+    padding: 0;
+  }
+}
+.header-main .name-site a {
+  display: block;
+  width: auto;
+}
+.header-main .logo-mit-lib {
+  fill: #fff;
+  padding: 8px;
+}
+.header-main .logo-mit-lib svg {
+  max-height: 28px;
+  max-height: 1.75rem;
+  height: auto;
+  width: 75px;
+}
+@media only screen and (min-width: 569px) {
+  .header-main .logo-mit-lib svg {
+    max-height: 44px;
+    max-height: 2.75rem;
+    width: 120px;
+  }
+}
+.header-main .logo-mit-lib title {
+  color: #000;
+  background-color: #fff;
+}
+.header-main .logo-mit-lib:hover {
+  background-color: #c702c7;
+}
+.header-main .logo-mit-lib:focus {
+  background-color: #c702c7;
+}
+.header-main .link-account,
+.header-main .link-site-search,
+.header-main .link-contact {
+  align-self: flex-end;
+  display: flex;
+  flex-direction: column;
+  order: 1000;
+  padding: 6.4px;
+  padding: 0.4rem;
+  color: #fff;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+.header-main .link-account:hover,
+.header-main .link-account:focus,
+.header-main .link-site-search:hover,
+.header-main .link-site-search:focus,
+.header-main .link-contact:hover,
+.header-main .link-contact:focus {
+  background-color: #c702c7;
+}
+.header-main .link-account svg,
+.header-main .link-site-search svg,
+.header-main .link-contact svg {
+  fill: #c8c8c8;
+  margin: 0 auto;
+  padding-bottom: 0.25em;
+  width: 2em;
+}
+.header-main .link-account i,
+.header-main .link-site-search i,
+.header-main .link-contact i {
+  color: #c8c8c8;
+  text-align: center;
+  font-size: 14px;
+}
+@media only screen and (min-width: 569px) {
+  .header-main .link-account,
+  .header-main .link-site-search,
+  .header-main .link-contact {
+    display: none;
+  }
+}
+.header-main .link-site-search {
+  margin-left: auto;
+}
+.header-main .link-account {
+  margin-left: 0.6rem;
+  margin-right: 0.6rem;
+}
+.header-main .link-contact {
+  margin-right: auto;
+}
+.header-main .link-logo-mit {
+  display: none;
+  align-self: flex-end;
+  order: 4;
+  padding-top: 32px;
+  padding-top: 2rem;
+  padding-bottom: 8px;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  max-width: 74px;
+  max-width: 73.6px;
+  max-width: 4.6rem;
+}
+@media only screen and (min-width: 569px) {
+  .header-main .link-logo-mit {
+    display: block;
+  }
+}
+.header-main .link-logo-mit:hover {
+  background-color: #c702c7;
+}
+.header-main .link-logo-mit:focus {
+  background-color: #c702c7;
+}
+.header-main .logo-mit {
+  display: block;
+  height: auto;
+  max-height: 45px;
+  max-height: 2.8125rem;
+  fill: #b9b7b6;
+}
+.header-main .logo-mit .color {
+  fill: #fff;
+}
+#skip a {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  background: #fff;
+  color: blue;
+  display: block;
+  padding: 10px;
+}
+#skip a:focus {
+  position: static;
+  width: auto;
+  height: auto;
+}
+@media only screen and (max-width: 320px) {
+  .no-flexbox.flexboxlegacy .header-main .icon-account,
+  .no-flexbox.flexboxlegacy .header-main .icon-search {
+    max-height: 16px;
+    max-height: 1rem;
+    max-width: 16px;
+    max-width: 1rem;
+  }
+}
+@media only screen and (max-width: 320px) {
+  .no-flexbox.flexboxlegacy .header-main .menu--toggle svg {
+    height: 100%;
+    padding: 1em;
+    width: auto;
+  }
+}
+.lte-ie9 .header-main {
+  height: 62px;
+  overflow: hidden;
+}
+.lte-ie9 .header-main * {
+  height: 62px;
+  overflow: hidden;
+}
+.lte-ie9 .header-main .name-site {
+  margin-left: 32px;
+  max-width: 103px;
+}
+.lte-ie9 .header-main .logo-mit {
+  margin-top: 24px;
+  margin-left: 40px;
+}
+.lte-ie9 .header-main .small {
+  font-size: 10px;
+  font-size: 0.625rem;
+  padding-top: 26px;
+  padding-top: 1.625rem;
+}
+.lte-ie9 .header-main .small svg {
+  display: none;
+}
+body.user-is-tabbing *.nav-main .main-nav-link.no-underline:focus {
+  text-decoration: none;
+  color: #fff;
+  background-color: #c702c7;
+}
+@media only screen and (min-width: 569px) {
+  body.user-is-tabbing *.nav-main .main-nav-link:focus {
+    background: #c702c7;
+  }
+}
+.nav-main {
+  flex-wrap: wrap;
+  transform: translateY(-1000%);
+  z-index: 7000;
+  margin: 0;
+  padding: 0;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+.nav-main.active {
+  font-size: 16px;
+  font-size: 1rem;
+  padding: 0px 8px 8px 8px;
+  padding: 0rem 0.5rem 0.5rem 0.5rem;
+  background: white;
+  box-shadow: 0 3px 3px #ccc;
+  height: auto;
+  flex: none;
+  position: absolute;
+  transform: translateY(2.8em);
+  top: 0;
+  width: 100%;
+}
+.nav-main.active a {
+  width: 100%;
+}
+.nav-main.active a:hover,
+.nav-main.active a:focus {
+  color: #fff;
+}
+@media only screen and (max-width: 1023px) {
+  .nav-main {
+    font-size: 0.9em;
+  }
+}
+@media only screen and (max-width: 800px) {
+  .nav-main {
+    font-size: 0.75em;
+  }
+}
+@media only screen and (min-width: 569px) {
+  .nav-main {
+    align-items: stretch;
+    height: auto;
+    flex-wrap: nowrap;
+    order: 3;
+    overflow: visible;
+    width: auto;
+    transform: translateY(0%);
+  }
+}
+.nav-main .small {
+  display: none;
+}
+@media only screen and (min-width: 569px) {
+  .nav-main .small {
+    display: block;
+    font-size: 0.75em;
+  }
+  .nav-main .small a {
+    padding: 1rem 0.5rem 0.5rem 0.5rem;
+    align-items: center;
+    flex-direction: column;
+    text-transform: uppercase;
+  }
+  .nav-main .small svg {
+    display: block;
+    fill: #fff;
+    margin-bottom: 0.4em;
+  }
+}
+@media only screen and (max-width: 1023px) {
+  .nav-main .small {
+    font-size: 1em;
+  }
+  .nav-main .small a {
+    text-transform: none;
+    padding-top: 2em;
+  }
+  .nav-main .small svg {
+    display: none;
+  }
+}
+.nav-main .chat {
+  display: none;
+}
+@media only screen and (min-width: 569px) {
+  .nav-main .chat {
+    display: block;
+  }
+  .nav-main .chat .links-sub {
+    min-width: 150px;
+    min-width: 9.375rem;
+    background: #f3f3f3;
+    flex-wrap: wrap;
+    width: auto;
+  }
+  .nav-main .chat .more {
+    font-size: 12px;
+    font-size: 0.75rem;
+    display: block;
+    text-align: center;
+    text-transform: none;
+    width: 100%;
+  }
+  .nav-main .chat .wrap-button-chat {
+    min-height: 46px;
+    min-height: 2.875rem;
+    padding: 16px 8px 0px 8px;
+    padding: 1rem 0.5rem 0rem 0.5rem;
+    min-width: 100%;
+  }
+  .nav-main .chat .wrap-button-chat #libchat_btn_widget {
+    border: 1px solid #666;
+  }
+}
+.nav-main .nav-main-list {
+  display: block;
+}
+@media only screen and (min-width: 569px) {
+  .nav-main .nav-main-list {
+    display: flex;
+    align-items: stretch;
+  }
+}
+.nav-main .link-primary {
+  position: relative;
+  transition: background-color 0.3s;
+  width: 100%;
+}
+@media only screen and (min-width: 569px) {
+  .nav-main .link-primary {
+    width: auto;
+  }
+}
+.nav-main .link-primary .links-sub {
+}
+.nav-main .main-nav-header {
+  height: 100%;
+  font-size: 100%;
+}
+.nav-main .main-nav-header button {
+  border: 0;
+  background: #fff;
+  background-image: none;
+  font-size: inherit;
+  padding: 0;
+}
+.nav-main .main-nav-link {
+  padding: 8px;
+  padding: 0.5rem;
+  display: block;
+  position: relative;
+}
+@media only screen and (min-width: 569px) {
+  .nav-main .main-nav-link {
+    border-bottom: none;
+    color: #fff;
+    display: flex;
+    height: 100%;
+    padding-top: 2em;
+  }
+}
+.nav-main .main-nav-link.active {
+  background: lightgray;
+  box-shadow:
+    0 0 2px #444,
+    inset 1px 0 0 gray,
+    inset -1px 0 0 gray,
+    inset 0 1px 0 gray;
+}
+.nav-main .main-nav-link.no-underline:hover {
+  text-decoration: none;
+  color: #fff;
+  background-color: #c702c7;
+}
+@media only screen and (min-width: 569px) {
+  .nav-main .main-nav-link:hover {
+    background: #c702c7;
+  }
+}
+.nav-main .col-1 {
+  background: #fff;
+}
+.nav-main .col-2 {
+  border-left: 1px solid #000;
+  background: #fff;
+}
+.nav-main .links-sub {
+  display: none;
+  left: 0;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  top: 100%;
+  transition:
+    max-height 0.3s,
+    margin 0.3s,
+    opacity 0.3s,
+    overflow 0.3s,
+    padding-top 0.3s,
+    padding-bottom 0.3s;
+  width: 31.75em;
+}
+.nav-main .links-sub.push {
+  left: auto;
+  right: 0;
+}
+@media only screen and (min-width: 569px) {
+  .nav-main .link-primary.open .main-nav-link {
+    background: #c702c7;
+  }
+}
+.nav-main .link-primary.open .links-sub {
+  display: none;
+}
+@media only screen and (min-width: 569px) {
+  .nav-main .link-primary.open .links-sub {
+    display: flex;
+    box-shadow: 0 0 2px #444;
+    max-height: 1000px;
+    opacity: 1;
+    overflow: visible;
+  }
+}
+.nav-main .links-sub {
+}
+.nav-main .links-sub a {
+  color: #000;
+  display: block;
+  font-weight: 600;
+  padding: 0.5em;
+}
+.nav-main .links-sub a:hover,
+.nav-main .links-sub a:focus {
+  background-color: #c702c7;
+  color: #fff;
+  text-decoration: none;
+}
+.nav-main .links-sub [class*="col-"] {
+  width: 50%;
+}
+.nav-main .links-sub .about {
+  display: block;
+  font-size: 0.6875em;
+  font-weight: normal;
+}
+.nav-main .links-sub .bottom {
+  border-top: 1px solid #000;
+}
+.nav-main .links-sub .bottom.extra span:first-of-type:after {
+  content: url(../../images/arrow-right-sfw.svg);
+  display: inline-block;
+  margin-left: 0.25em;
+}
+.nav-main .links-sub .bottom:not(.extra):after {
+  content: url(../../images/arrow-right-sfw.svg);
+  display: inline-block;
+  margin-left: 0.25em;
+}
+.nav-main .bottom:not(.extra) span:not(:first-of-type):before {
+  color: #007db8;
+  content: "|";
+  display: inline-block;
+  margin-right: 4px;
+}
+.nav-main .heading-col {
+  margin: 16px 0px 8px 8px;
+  margin: 1rem 0rem 0.5rem 0.5rem;
+  color: #000;
+  display: block;
+  font-size: 0.75em;
+  font-weight: bold;
+  text-transform: uppercase;
+  padding-bottom: 0;
+}
+.nav-page {
+  margin-bottom: 1rem !important;
+}
+.no-csstransitions .link-primary .links-sub {
+  height: 0;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 0;
+}
+.no-csstransitions .link-primary:hover .links-sub,
+.no-csstransitions .link-primary:focus .links-sub {
+  height: auto;
+  margin: auto;
+  overflow: visible;
+  padding: 16px;
+  padding: 1rem;
+  width: 600px;
+}
+.nav-secondary {
+  border-bottom: 1px solid #dedede;
+  font-size: 16px;
+  font-size: 1rem;
+  margin: 0 20px;
+  z-index: 7000;
+}
+@media only screen and (max-width: 320px) {
+  .nav-secondary {
+    background: #333;
+    height: 0;
+    margin: 0;
+    overflow: hidden;
+    padding: 0;
+  }
+  .nav-secondary.active {
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    padding: 0;
+  }
+}
+.nav-secondary ul {
+  list-style: none;
+}
+.nav-secondary .menu > ul > li {
+  display: inline-block;
+  position: relative;
+}
+@media only screen and (max-width: 320px) {
+  .nav-secondary .menu > ul > li {
+    display: block;
+  }
+}
+.nav-secondary .menu > ul > li:nth-child(n + 4) ul {
+  right: 0;
+}
+.nav-secondary .menu > ul > li:hover {
+  background: #dedede;
+  box-shadow: 0 0 2px #444;
+  transition: background-color 0.3s;
+}
+@media only screen and (max-width: 320px) {
+  .nav-secondary .menu > ul > li:hover {
+    background: none;
+    box-shadow: none;
+  }
+}
+.nav-secondary .menu > ul > li:hover li {
+  background: #dedede;
+  border-top: 1px solid #ababab;
+  height: auto;
+  line-height: 1;
+  margin: auto;
+  opacity: 1;
+  overflow: visible;
+  width: 100%;
+  z-index: 7000;
+  transition: opacity 0.3s;
+}
+@media only screen and (max-width: 320px) {
+  .nav-secondary .menu > ul > li:hover li {
+    display: none;
+  }
+}
+.nav-secondary .menu > ul > li:hover li a {
+  display: block;
+  padding: 16px;
+  padding: 1rem;
+}
+.nav-secondary .menu > ul > li > a {
+  display: block;
+  padding: 16px;
+  padding: 1rem;
+}
+@media only screen and (max-width: 320px) {
+  .nav-secondary .menu > ul > li > a {
+    color: white;
+  }
+}
+.nav-secondary .menu > ul > li li {
+  height: 0;
+  line-height: 0;
+  margin: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  position: relative;
+  width: 0;
+}
+.nav-secondary .menu > ul > li ul {
+  box-shadow: 0 1px 2px #444;
+  position: absolute;
+  width: 320px;
+  width: 20rem;
+}
+.nav-second > li > a:hover {
+  color: #0000ff !important;
+  text-decoration: underline;
+}
+.mobile-display {
+  display: none;
+}
+.hide-mobile-nav-link {
+  display: none;
+}
+.menu--toggle {
+  min-width: 51px;
+  min-width: 3.1875rem;
+  font-size: 16px;
+  font-size: 1rem;
+  background: #000;
+  cursor: pointer;
+  fill: #ebf5ff;
+  order: 1;
+  width: 14.375%;
+  z-index: 7000;
+}
+@media only screen and (min-width: 569px) {
+  .menu--toggle {
+    display: none;
+  }
+}
+.menu--toggle svg {
+  display: block;
+  margin: 1em auto;
+}
+.menu--toggle:hover,
+.menu--toggle:focus {
+  background-color: #c702c7;
+  background-image: none;
+}
+.no-flexbox .link-primary.chat:hover .links-sub,
+.no-flexbox .link-primary.chat:focus .links-sub {
+  display: block;
+}
+.no-flexbox .link-primary.chat:hover .links-sub a,
+.no-flexbox .link-primary.chat:focus .links-sub a {
+  display: block;
+  width: 100%;
+}
+.lte-ie9 .nav-main .links-sub {
+  display: none;
+}
+@media screen and (min-width: 568px) and (max-width: 700px) {
+  .link-primary .search-link {
+    padding-right: 2em;
+  }
+  .link-primary .account-link {
+    padding-left: 1em;
+    padding-right: 1em;
+  }
+}
+
+/* 2. Footer */
+.footer-main {
+  background: #000 url(../../images/vi-shape7-tp.png) no-repeat 10% center;
+  flex-wrap: wrap;
+  clear: both;
+  width: 100%;
+}
+@media only screen and (min-width: 569px) {
+  .footer-main {
+    padding: 1.25em 1.375em;
+  }
+}
+@media only screen and (min-width: 569px) {
+  .footer-main {
+    width: 100%;
+  }
+}
+.footer-main a {
+  color: #f3f3f3;
+}
+.footer-main .identity {
+  flex-wrap: wrap;
+  padding: 2em 0 0;
+}
+@media only screen and (min-width: 569px) {
+  .footer-main .identity {
+    align-items: flex-end;
+    justify-content: space-between;
+    width: 100%;
+  }
+}
+.footer-main .links-primary {
+  border-top: 1px solid #808285;
+  border-bottom: 1px solid #808285;
+  flex-wrap: wrap;
+  font-size: 0.8125em;
+  margin-top: 2em;
+  padding: 2rem 1.375rem;
+  width: 100%;
+}
+@media only screen and (min-width: 569px) {
+  .footer-main .links-primary {
+    border-top: none;
+    border-bottom: none;
+    font-size: 0.875em;
+    margin-top: -22.4px;
+    margin-top: -1.4rem;
+    margin-left: 184px;
+    margin-left: 11.5rem;
+    padding: 0;
+    z-index: 3000;
+  }
+}
+@media only screen and (max-width: 1023px) {
+  .footer-main .links-primary {
+    margin-top: 24px;
+    margin-top: 1.5rem;
+    margin-left: 0px;
+    margin-left: 0rem;
+  }
+}
+.footer-main .links-primary span {
+  display: block;
+  width: 50%;
+}
+@media only screen and (min-width: 569px) {
+  .footer-main .links-primary span {
+    font-weight: 300;
+    padding-left: 1em;
+    width: auto;
+  }
+  .footer-main .links-primary span:not(:last-of-type):after {
+    color: #dedede;
+    content: "|";
+    display: inline-block;
+    margin-left: 1em;
+  }
+}
+@media only screen and (max-width: 1023px) {
+  .footer-main .links-primary span:first-of-type {
+    padding-left: 0;
+  }
+}
+.footer-main .logo-mit-lib {
+  display: block;
+  fill: #fff;
+  padding-left: 1.375em;
+  width: 10.3125em;
+}
+@media only screen and (min-width: 569px) {
+  .footer-main .logo-mit-lib {
+    padding-left: 0;
+    max-width: 9.5em;
+    width: 9.5em;
+  }
+}
+.footer-main .logo-mit-lib svg {
+  max-height: 4em;
+  max-width: 9.5em;
+  fill: #fff;
+}
+.footer-main .logo-mit-lib title {
+  color: #000;
+  background-color: #fff;
+}
+.footer-main .text-find-us {
+  color: #ebebeb;
+  display: none;
+  margin-bottom: 0 !important;
+  font-size: 0.625em;
+  font-weight: bold;
+  text-transform: uppercase;
+  min-width: 7em;
+}
+@media only screen and (min-width: 569px) {
+  .footer-main .text-find-us {
+    display: block;
+  }
+}
+.footer-main .social {
+  align-items: center;
+  flex-wrap: wrap;
+  padding-left: 1.375em;
+  width: auto;
+  min-width: 12em;
+}
+@media only screen and (min-width: 569px) {
+  .footer-main .social {
+    flex-wrap: nowrap;
+    margin-bottom: 0.2em;
+    z-index: 4000;
+  }
+}
+.footer-main .social a {
+  width: 33%;
+}
+.footer-main .social a:hover {
+  text-decoration: none;
+}
+@media only screen and (min-width: 569px) {
+  .footer-main .social a {
+    width: 20%;
+  }
+  .footer-main .social a:not(:last-of-type) {
+    margin-right: 0.5em;
+  }
+}
+.footer-main .social [class*="icon-social"] {
+  background: #dedede;
+  border-radius: 50%;
+  height: 1.5em;
+  padding: 0.2em;
+  width: 1.5em;
+}
+.footer-main .social [class*="icon-social"] path {
+  fill: #474747;
+}
+@media only screen and (min-width: 569px) {
+  .footer-main .social [class*="icon-social"] {
+    height: 2em;
+    padding: 0.2em;
+    width: 2em;
+  }
+}
+.footer-info-institute {
+  align-items: start;
+  background: #333;
+  display: flex;
+  justify-content: space-between;
+  padding: 1.25em 1.375em;
+}
+.footer-info-institute .license {
+  color: #fff;
+  font-size: 0.6875em;
+  margin-left: auto;
+  max-width: 400px;
+  max-width: 25rem;
+}
+.footer-info-institute .license a {
+  color: #ededed;
+  text-decoration: underline;
+}
+.footer-info-institute .link-logo-mit {
+  display: block;
+  margin-right: 50px;
+  margin-right: 3.125rem;
+  min-width: 152px;
+  min-width: 9.5rem;
+}
+.no-flexbox .footer-info-institute {
+  display: block;
+}
+.no-flexbox .footer-info-institute:after {
+  clear: both;
+  content: "";
+  display: table;
+}
+.no-flexbox .footer-info-institute > a,
+.no-flexbox .footer-info-institute > div {
+  float: left;
+}
+.no-flexbox .footer-info-institute .link-logo-mit {
+  padding-top: 1.5em;
+}
+.no-flexbox .footer-main.flex-container {
+  display: block;
+  float: left;
+}
+.no-flexbox .footer-main:after {
+  clear: both;
+  content: "";
+  display: table;
+}
+.no-flexbox .footer-main .identity {
+  position: relative;
+  width: 100%;
+}
+.no-flexbox .footer-main .identity .logo-mit-lib {
+  display: block;
+  float: left;
+}
+.no-flexbox .footer-main .identity .social {
+  bottom: 0;
+  display: block;
+  right: 22px;
+  position: absolute;
+}
+.no-flexbox .footer-main .links-primary {
+  display: block;
+  margin-top: 0;
+  margin-left: 0;
+  left: 202px;
+  position: absolute;
+  top: 79px;
+  width: 100%;
+}
+.no-flexbox .footer-main .links-primary span {
+  display: block;
+  float: left;
+  position: relative;
+}
+.no-flexbox.flexboxlegacy .footer-main {
+  overflow-x: hidden;
+}
+.lte-ie9.no-flexbox .footer-main .identity {
+  width: 100%;
+}
+
+/* 3. no-flexbox fallbacks */
+.no-flexbox.no-flexboxlegacy .flex-clear {
+  clear: both
+}
+
+.no-flexbox.no-flexboxlegacy .flex-container {
+  display: block
+}
+
+.no-flexbox.no-flexboxlegacy .flex-container>a,
+.no-flexbox.no-flexboxlegacy .flex-container>button,
+.no-flexbox.no-flexboxlegacy .flex-container>div,
+.no-flexbox.no-flexboxlegacy .flex-container>form,
+.no-flexbox.no-flexboxlegacy .flex-container>h1,
+.no-flexbox.no-flexboxlegacy .flex-container>h2,
+.no-flexbox.no-flexboxlegacy .flex-container>h3,
+.no-flexbox.no-flexboxlegacy .flex-container>header,
+.no-flexbox.no-flexboxlegacy .flex-container>input,
+.no-flexbox.no-flexboxlegacy .flex-container>nav,
+.no-flexbox.no-flexboxlegacy .flex-container>span,
+.no-flexbox.no-flexboxlegacy .flex-container>svg,
+.no-flexbox.no-flexboxlegacy .flex-container>ul {
+  float: left;
+  width: auto
+}
+
+.no-flexbox.no-flexboxlegacy .flex-container:after {
+  clear: both;
+  content: '';
+  display: table
+}
+
+.no-flexbox.no-flexboxlegacy .flex-item {
+  float: left
+}
+
+/* 4. hiding and showing elements based on mobile classes */
+.hidden-mobile {
+  display: none;
+}
+@media only screen and (min-width: 569px) {
+  .hidden-mobile {
+    display: block;
+  }
+}
+.inactive-mobile {
+  opacity: 0;
+}
+@media only screen and (min-width: 321px) {
+  .inactive-mobile {
+    opacity: 1;
+  }
+}
+.hidden-non-mobile {
+  display: block;
+}
+@media only screen and (min-width: 569px) {
+  .hidden-non-mobile {
+    display: none;
+  }
+}
+
+/* Local overrides for libguides */
+
+/* Reset only what you need */
+.header-main,
+footer {
+  max-width: 1170px; /* matches .container */
+  width: 100%;
+  margin: 0 auto;
+}
+
+.header-main {
+  padding: 0 20px;
+}
+
+.header-main .name-site {
+  margin: 0;
+  padding: 0;
+}
+
+@media only screen and (max-width:568px) {
+  .header-main>[class*=link] {
+    font-size: 9px
+  }
+  .header-main {
+    padding: 0;
+  }
+  .header-main .menu--toggle {
+    margin: auto 0;
+  }
+  .header-main .logo-mit-lib {
+    padding-left: 0;
+  }
+}
+
+/* The rules in this media query primarily set alignment for the logos and nav */
+@media only screen and (min-width: 569px) {
+  .header-main {
+    height: 75px; /* matches height of logos, including 20px top/bottom padding */
+  }
+  .header-main .name-site {
+    max-width: 100%;
+  }
+  .nav-main,
+  .nav-main .nav-main-list,
+  .nav-main .nav-main-list li,
+  .nav-main .small a,
+  .nav-main .main-nav-link {
+    height: 100%;
+  }
+  .header-main .logo-mit-lib {
+    padding: 20px 0;
+    vertical-align: baseline;
+  }
+  .nav-main {
+    margin: 0 10px;
+  }
+  .header-main .link-site-search,
+  .header-main .link-account {
+    padding: 20px 0;
+  }
+  .nav-main .small a {
+    flex-direction: column;
+    align-items: center;
+    padding-top: 20px;
+    padding-bottom: 20px;
+  }
+  .nav-main .main-nav-link {
+    margin: 0;
+    padding: 20px 8px;
+  }
+  .header-main .link-logo-mit {
+    display: none
+  }
+}
+
+/* 635px is the maximum width before the logos will shrink if both are displayed */
+@media only screen and (min-width: 635px) {
+  .header-main .link-logo-mit {
+    display: block;
+    padding: 20px 0;
+    vertical-align: baseline;
+  }
+}
+
+@media only screen and (max-width: 1023px) {
+  .nav-main .small a {
+    flex-direction: row; /* flex-direction and alignment needs to change when the SVGs are hidden */
+    align-items: flex-end;
+    height: 100%;
+    padding-top: 20px;
+    padding-bottom: 20px;
+  }
+}
+
+.header-main h2 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  font-size: 100%;
+  vertical-align: baseline;
+  background: 0 0;
+}
+
+.header-main ul {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  font-size: 100%;
+  vertical-align: baseline;
+  background: 0 0;
+  list-style-type: none;
+}
+
+footer a,
+header a {
+  color: #000;
+  text-decoration: none;
+}
+footer a:hover,
+footer a:focus {
+  color: #fff;
+  text-decoration: underline;
+}
+
+h1#s-lg-guide-name {
+    font-size: 30px;
+}
+
+.s-lib-box-content .ui-widget {
+    font-family: Helvetica, "Open Sans", sans-serif;
+    font-size: 16px; /* was 100%; */
+    line-height: 1.4;
+    text-rendering: optimizeLegibility;
+}
+
+.tabs a {
+  text-decoration: none;
+}
+
+.ui-widget-content a {
+  text-decoration: underline;
+  color: #000;
+}
+
+.ui-widget-content a:hover {
+  color: #00f;
+}
+
+table, th, td {
+    padding: 5px;
+}
+
+#s-lg-guide-description,
+#s-lg-guide-header-search,
+#s-lib-bc,
+#s-lg-guide-header-updated,
+#s-lg-guide-header-url,
+#s-lg-guide-print-url,
+#s-lg-guide-header-subjects,
+#s-lg-guide-header-tags {
+ display:
+ none;
+}
+
+#s-lg-guide-header {
+ margin-top: 15px;
+}
+
+#s-lg-guide-name {
+ font-weight: 400;
+}
+
+.s-lib-box .s-lib-box-title {
+ font-size: 18px;
+ color: #111;
+}
+
+.s-lib-box {
+ color: #111;
+}
+
+.s-lib-box-content {
+ padding: 20px;
+}
+
+/* Hides Email Me button*/
+.s-lib-profile-email > a {
+    display: none;
+}
+
+/*Hides website, Skype, & Social links from profile*/
+.fa-bookmark, .fa-skype, .s-lib-profile-social {
+ display: none;
+}
+
+/* Overriding the accordion markup with changeable arrows */
+.accordion-group .accordion-toggle {
+  margin-left: 0px;
+  background: url('https://libraries.mit.edu/images/libguides-arrow-down.png') no-repeat left center;
+  padding-left: 15px;
+}
+.accordion-group .accordion-toggle.collapsed {
+  background-image: url('https://libraries.mit.edu/images/libguides-arrow-right.png')
+}
+
+/* BartonPlus search box */
+#s-lg-box-3500974-container input {
+  display: inline-block;
+  margin-right: 5px;
+  vertical-align: top;
+}
+#s-lg-box-3500974-container label {
+  font-weight: normal;
+  max-width: 80%;
+  vertical-align: top;
+}
+
+/*Hides guide author, last updated date, and number of views this year from guide lists*/
+.s-lg-system-list .s-lg-guide-list-info {
+ display: none;
+ font-size: 0.9em;
+}
+
+/*Hides "skip to main content" link in top left of banner*/
+a#s-lg-public-skiplink { 
+position:absolute; 
+left:-10000px; 
+top:auto; 
+width:1px; 
+height:1px; 
+overflow:hidden;
+} 
+ 
+a:focus#s-lg-public-skiplink { 
+position:static; 
+width:auto; 
+height:auto; 
+} 
+
+/* staff contact card styles */
+.contact-card .wrap-contact-image {
+  display: inline-block; 
+  vertical-align: middle; 
+  margin-right: 15px;
+}
+
+.contact-card .wrap-contact-info {
+  display: inline-block; 
+  vertical-align: middle;
+}
+
+.contact-card .wrap-contact-help {
+  display: block;
+}
+
+/* customize browzine widget */
+#browzineWidget .smallWidget {
+  width: auto !important;
+  float: none !important;
+  background-size: contain !important;
+}
+
+#browzineWidget .smallWidget .widgetText {
+  width: auto !important;
+  float: none !important;
+  padding: 10px;
+}
+
+#browzineWidget .widgetText .intro {
+  text-align: center !important;
+}
+
+/* customize Worldcat search box */
+.s-lg-box-wrapper-25193671 {
+    font-size: .8em;
+}
+.s-lg-box-wrapper-25193671 .s-lib-box-content {
+  padding: 0 1em;
+}
+
+.s-lg-box-wrapper-25193671 input {
+  padding: .5em !important; 
+  min-width: 5em !important; 
+}
+.s-lg-box-wrapper-25193671 #discovery-search-form {
+  padding: 1em;
+}
+
+/* Styling for COVID-19 info banner */
+.alert-banner {
+  display: block;
+  margin: 1rem auto;
+  border-radius: 2px;
+  padding: 1.6rem 2rem;
+  border: 1px solid #000;
+  border-top: 5px solid #000;
+  color: #000;
+  font-weight: 600;
+}
+.alert-banner .fa {
+  display: inline-block;
+  margin-right: 0.5em;
+}
+</style>

--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -137,7 +137,7 @@ h3 {
 /* 1. Header & Nav */
 .header-main {
   position: relative;
-  background: #000 url('https://libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 0 65%;
+  background: #000 url('https://cdn.libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 0 65%;
   clear: both;
   width: 100%;
 }
@@ -811,7 +811,7 @@ body.user-is-tabbing *.nav-main .main-nav-link.no-underline:focus {
 
 /* 2. Footer */
 .footer-main {
-  background: #000 url(../../images/vi-shape7-tp.png) no-repeat 10% center;
+  background: #000 url('https://cdn.libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 10% center;
   flex-wrap: wrap;
   clear: both;
   width: 100%;
@@ -1319,11 +1319,11 @@ table, th, td {
 /* Overriding the accordion markup with changeable arrows */
 .accordion-group .accordion-toggle {
   margin-left: 0px;
-  background: url('https://libraries.mit.edu/images/libguides-arrow-down.png') no-repeat left center;
+  background: url('https://cdn.libraries.mit.edu/images/libguides-arrow-down.png') no-repeat left center;
   padding-left: 15px;
 }
 .accordion-group .accordion-toggle.collapsed {
-  background-image: url('https://libraries.mit.edu/images/libguides-arrow-right.png')
+  background-image: url('https://cdn.libraries.mit.edu/images/libguides-arrow-right.png')
 }
 
 /* BartonPlus search box */

--- a/libguides/custom-header-js-az.html
+++ b/libguides/custom-header-js-az.html
@@ -1,0 +1,58 @@
+<script>
+jQuery(document).ready(function($) {
+  jQuery("img[alt='null'], img[alt='Null'], img[alt='NULL']").attr("alt", "");
+  var libchat_efc75c55947db323d4faab725b79307f = { iid:59, key:'fb10446730e271c', width:'240' };
+
+  $('header .menu--toggle').click(function(){
+    $('#nav-main').toggleClass('active');
+    $('.wrap-page').toggleClass('mobile-nav-active');
+  });
+
+  $( '.link-primary' ).bind( "mouseenter", function() { 
+    $( '.link-primary' ).removeClass( 'open' );
+    $(this).find( '.menu-control' ).attr( 'aria-expanded', 'true' );
+    $(this).closest( '.link-primary' ).addClass( 'open' );
+  });
+  $( '.link-primary' ).bind( "mouseleave", function() { 
+    $(this).find( '.menu-control' ).attr( 'aria-expanded', 'false' );
+    $( '.link-primary' ).removeClass( 'open' );
+  });
+
+  // make esc close all menus
+  $( '#nav-main' ).on( 'keydown' , function(e) {
+    if (e.keyCode == 27) {
+      hideMenu(e);
+    }
+  });
+
+  function hideMenu() {
+    $( '.link-primary' ).removeClass( 'open' );
+    $( '.menu-control' ).attr('aria-expanded', 'false');
+    $( '.links-sub' ).attr( 'aria-hidden', 'true' );
+  }
+
+  // thanks to http://heydonworks.com/practical_aria_examples/
+  $('.main-nav-header').each(function() {
+
+    var $this = $(this);
+
+    // create unique id for a11y relationship
+    var id = 'collapsible-' + $( '#nav-main h2' ).index(this);
+
+    // identify panel and make it focusable
+    var panel = $(this).next( '.links-sub' ).attr( 'aria-hidden', 'true' ).attr( 'id', id);
+
+    // Add default aria states to button
+    $this.children( '.menu-control' ).attr( 'aria-expanded', 'false' ).attr( 'aria-controls', id);
+    var button = $this.children( '.menu-control' );
+
+    // Toggle the state properties
+    button.on( 'click', function() {
+      $(this).closest( '.link-primary' ).toggleClass( 'open' );
+      var state = $(this).attr( 'aria-expanded' ) === 'false' ? true : false;
+      $(this).attr( 'aria-expanded', state );
+      panel.attr( 'aria-hidden', !state );
+    });
+  });
+});
+</script>


### PR DESCRIPTION
#### Why these changes are being introduced:

Springshare will soon release a revamped A-Z Databases. We need
to update our custom CSS and JS to accommodate the changes.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/UXWS-1621

#### How this addresses that need:

* Adds the following requested changes:
    * Restyling form elements.
    * Changing certain font colors to #000.
    * Changing certain background colors for higher contrast.
    * Normalizing font size at 16px (1rem).
    * Updating media query breakpoints for the header and footer (A-Z has moved from Bootstrap 3 to 5; more on this in side effects).
* Moves custom JS to `custom-footer-js` and `custom-header-js`
files, as the new System Settings allow for this. (They oddly still
require everything to be wrapped in `script` tags, which is why
these are still HTML files.)

#### Side effects of this change:

* Springshare has indicated that the current System Settings
(i.e., custom CSS/JS) for A-Z will eventually also apply to LibGuides.
If they do this before updating LibGuides to Bootstrap 5, then the
media queries set for A-Z won't correspond with the ones in LibGuides.
I've asked Springshare for more clarification on this, and Dhruti and
I will develop a backup plan (most likely a fluid header/footer) if
they intend to collapse the settings before updating LibGuides.
* The footer background png had been using a relative path. I updated
this to the full URL in both the LibGuides and A-Z CSS.
* Matomo code has _not_ been added to the footer JS. We currently add
it to the Custom Analytics section of  LibGuides' system settings. It's
unclear to me if this will remain  the case when the new A-Z Databases
launches, but we'll want to check on it post-launch as it may affect
data collection.