### PR TITLE
Update LibWizards navigation to have white text on hover

### DIFF
--- a/libwizard/custom-head.html
+++ b/libwizard/custom-head.html
@@ -162,7 +162,6 @@ h3 {
 .header-main .link-contact:hover,
 .header-main .link-contact:focus {
   background-color: #c702c7;
-  color: #fff;
 }
 .header-main .link-account svg,
 .header-main .link-site-search svg,

--- a/libwizard/custom-head.html
+++ b/libwizard/custom-head.html
@@ -162,6 +162,7 @@ h3 {
 .header-main .link-contact:hover,
 .header-main .link-contact:focus {
   background-color: #c702c7;
+  color: #fff;
 }
 .header-main .link-account svg,
 .header-main .link-site-search svg,
@@ -472,7 +473,7 @@ body.user-is-tabbing *.nav-main .main-nav-link.no-underline:focus {
 }
 .nav-main .main-nav-link.no-underline:hover {
   text-decoration: none;
-  color: #fff;
+  color: #fff !important;
   background-color: #c702c7;
 }
 @media only screen and (min-width: 569px) {


### PR DESCRIPTION
### Why these changes are being introduced

Previously, when hovering over a navigation item in LibWizards the text color was navy on a pink background. This led to contrast problems that would fail accessibility tests.

### How this addresses that need

I forced the text color to be white to make sure that there's ample contrast to meet WCAG AA.

### Side effects of this change

n/a

### Relevant ticket(s)
https://mitlibraries.atlassian.net/browse/UXWS-1695
