### PR TITLE
Fixed navigation text hover color on LibWizard for mobile breakpoint

### DIFF
--- a/libwizard/custom-head.html
+++ b/libwizard/custom-head.html
@@ -858,6 +858,7 @@ body.user-is-tabbing *.nav-main .main-nav-link.no-underline:focus {
   .header-main .link-accessibility:focus {
     background-color: #c702c7;
     text-decoration: none;
+    color: #fff !important;
   }
   .header-main .link-privacy {
     margin-left: auto;


### PR DESCRIPTION
### Why these changes are being introduced
On mobile devices, the navigation hover text color was a navy blue, and on top of our pink it was a low contrast ratio.

### How this addresses that need
This change forces that text color to be white on mobile breakpoints.

### Side effects of this change
N/A

### Relevant ticket(s)
https://mitlibraries.atlassian.net/browse/UXWS-1695
